### PR TITLE
Feat/dispatcher dashboard prototype

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { IBM_Plex_Sans } from "next/font/google";
+import { DashboardNav } from "@/components/dispatcher/dashboard-nav";
+import { DispatchProvider } from "@/components/dispatcher/dispatch-provider";
+
+const plexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-dashboard-body",
+});
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <DispatchProvider>
+      <div
+        className={`${plexSans.variable} min-h-screen bg-stone-100 px-4 py-6 text-slate-900 md:px-6 lg:px-8`}
+        style={{ fontFamily: "var(--font-dashboard-body)" }}
+      >
+        <div className="pointer-events-none fixed inset-0 opacity-50 [background:radial-gradient(circle_at_10%_8%,rgba(15,23,42,.06),transparent_34%),radial-gradient(circle_at_82%_4%,rgba(15,23,42,.04),transparent_30%)]" />
+        <div className="pointer-events-none fixed inset-0 opacity-25 [background-image:linear-gradient(rgba(100,116,139,.22)_1px,transparent_1px),linear-gradient(90deg,rgba(100,116,139,.22)_1px,transparent_1px)] [background-size:40px_40px]" />
+
+        <div className="relative z-10 mx-auto w-full max-w-[1280px]">
+          <header className="mb-6 rounded-2xl border border-slate-300 bg-white/95 p-5 shadow-[0_16px_36px_rgba(15,23,42,.08)] backdrop-blur">
+            <div className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-200 pb-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-600">
+                  City Ops Grid
+                </p>
+                <h1
+                  className="mt-1 text-2xl tracking-[0.08em] text-slate-900 md:text-3xl"
+                >
+                  911 Dispatch Center
+                </h1>
+                <p className="mt-1 text-sm text-slate-500">
+                  AI Voice Operations Dashboard
+                </p>
+              </div>
+              <span className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-slate-100 px-3 py-2 text-xs uppercase tracking-[0.14em] text-slate-700">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-slate-500" />
+                Live
+              </span>
+            </div>
+            <div className="mt-4">
+              <DashboardNav />
+            </div>
+          </header>
+          <main>{children}</main>
+        </div>
+      </div>
+    </DispatchProvider>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { OverviewPage } from "@/components/dispatcher/overview-page";
+
+export default function DashboardOverviewRoute() {
+  return <OverviewPage />;
+}

--- a/app/dashboard/queue/page.tsx
+++ b/app/dashboard/queue/page.tsx
@@ -1,0 +1,5 @@
+import { QueuePage } from "@/components/dispatcher/queue-page";
+
+export default function DashboardQueueRoute() {
+  return <QueuePage />;
+}

--- a/app/dashboard/simulator/page.tsx
+++ b/app/dashboard/simulator/page.tsx
@@ -1,0 +1,5 @@
+import { CallInterface } from "@/components/ui/call-interface";
+
+export default function DashboardSimulatorRoute() {
+  return <CallInterface />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -123,73 +123,48 @@
   body {
     @apply bg-background text-foreground;
   }
+  .maplibregl-popup-content {
+    @apply bg-transparent! shadow-none! p-0! rounded-none!;
+  }
+  .maplibregl-popup-tip {
+    @apply hidden!;
+  }
 }
 
-/* ── 911 Dispatch Design System ── */
-
-/* Waveform bar animation — staggered sine-wave effect */
+/* 911 Dispatch Design System */
 @keyframes waveform-bar {
   0%, 100% { transform: scaleY(0.3); }
   50% { transform: scaleY(1); }
 }
 
-/* Gentle fade-in-up for transcript messages */
 @keyframes fade-in-up {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-/* Slow breathing glow for the call button */
 @keyframes glow-breathe {
   0%, 100% { box-shadow: 0 0 20px 0 rgba(220, 38, 38, 0.3); }
   50% { box-shadow: 0 0 36px 6px rgba(220, 38, 38, 0.5); }
 }
 
-/* Typing cursor blink */
 @keyframes cursor-blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
 }
 
-/* Smooth ring expand for connecting state */
 @keyframes ring-expand {
   0% { transform: scale(1); opacity: 0.6; }
   100% { transform: scale(1.6); opacity: 0; }
 }
 
-.animate-waveform-bar {
-  animation: waveform-bar ease-in-out infinite;
-}
+.animate-waveform-bar { animation: waveform-bar ease-in-out infinite; }
+.animate-fade-in-up { animation: fade-in-up 0.3s cubic-bezier(0.16, 1, 0.3, 1) both; }
+.animate-glow-breathe { animation: glow-breathe 2.5s ease-in-out infinite; }
+.animate-cursor-blink { animation: cursor-blink 1s step-end infinite; }
+.animate-ring-expand { animation: ring-expand 1.4s cubic-bezier(0.16, 1, 0.3, 1) infinite; }
 
-.animate-fade-in-up {
-  animation: fade-in-up 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-.animate-glow-breathe {
-  animation: glow-breathe 2.5s ease-in-out infinite;
-}
-
-.animate-cursor-blink {
-  animation: cursor-blink 1s step-end infinite;
-}
-
-.animate-ring-expand {
-  animation: ring-expand 1.4s cubic-bezier(0.16, 1, 0.3, 1) infinite;
-}
-
-/* Custom scrollbar for transcript */
-.scrollbar-dispatch::-webkit-scrollbar {
-  width: 4px;
-}
-.scrollbar-dispatch::-webkit-scrollbar-track {
-  background: transparent;
-}
+.scrollbar-dispatch::-webkit-scrollbar { width: 4px; }
+.scrollbar-dispatch::-webkit-scrollbar-track { background: transparent; }
 .scrollbar-dispatch::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.08);
   border-radius: 9999px;
@@ -198,7 +173,6 @@
   background: rgba(255, 255, 255, 0.15);
 }
 
-/* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .animate-waveform-bar,
   .animate-fade-in-up,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { CallInterface } from "@/components/ui/call-interface";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return <CallInterface />;
+  redirect("/dashboard");
 }

--- a/components/dispatcher/dashboard-nav.tsx
+++ b/components/dispatcher/dashboard-nav.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Activity, PhoneCall, Radio } from "lucide-react";
+
+const tabs = [
+  { href: "/dashboard", label: "Overview", icon: Activity },
+  { href: "/dashboard/queue", label: "Current Queue", icon: PhoneCall },
+  { href: "/dashboard/simulator", label: "Call Simulator", icon: Radio },
+];
+
+export function DashboardNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="grid gap-2 sm:grid-cols-3">
+      {tabs.map((tab) => {
+        const active = pathname === tab.href;
+        const Icon = tab.icon;
+
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`inline-flex h-12 items-center justify-center gap-2 rounded-lg border px-4 text-sm tracking-wide transition ${
+              active
+                ? "border-slate-400 bg-slate-200 text-slate-900"
+                : "border-slate-200 bg-slate-50 text-slate-600 hover:border-slate-400 hover:text-slate-900"
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/dispatcher/dispatch-provider.tsx
+++ b/components/dispatcher/dispatch-provider.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { INITIAL_CALLS, priorityWeight, randomLiveLine } from "./mock-data";
-import type { CallStatus, DispatchCall, EmergencyType } from "./types";
+import type { CallStatus, DispatchCall, EmergencyType, TranscriptLine } from "./types";
 
 interface DashboardMetrics {
   totalCallsToday: number;
@@ -99,14 +99,16 @@ export function DispatchProvider({ children }: { children: ReactNode }) {
             return call;
           }
 
+          const nextLine: TranscriptLine = {
+            id: `t-${Date.now()}`,
+            speaker: Math.random() > 0.6 ? "caller" : "dispatcher",
+            text: randomLiveLine(),
+            timestamp: Date.now(),
+          };
+
           const nextTranscript = [
             ...call.transcript,
-            {
-              id: `t-${Date.now()}`,
-              speaker: Math.random() > 0.6 ? "caller" : "dispatcher",
-              text: randomLiveLine(),
-              timestamp: Date.now(),
-            },
+            nextLine,
           ];
 
           return {

--- a/components/dispatcher/dispatch-provider.tsx
+++ b/components/dispatcher/dispatch-provider.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { INITIAL_CALLS, priorityWeight, randomLiveLine } from "./mock-data";
+import type { CallStatus, DispatchCall, EmergencyType } from "./types";
+
+interface DashboardMetrics {
+  totalCallsToday: number;
+  ongoingCalls: number;
+  dispatchSent: number;
+  resolvedCalls: number;
+  avgTimeToDispatchMins: number;
+  highPriorityCount: number;
+}
+
+interface CallsByType {
+  Medical: number;
+  Fire: number;
+  Police: number;
+}
+
+interface HourlyPoint {
+  hour: string;
+  count: number;
+}
+
+interface DispatchContextValue {
+  now: number;
+  calls: DispatchCall[];
+  selectedCallId: string | null;
+  metrics: DashboardMetrics;
+  callsByType: CallsByType;
+  callsByHour: HourlyPoint[];
+  selectCall: (callId: string) => void;
+  updateCallStatus: (callId: string, status: CallStatus) => void;
+  updateCallNotes: (callId: string, notes: string) => void;
+}
+
+const DispatchContext = createContext<DispatchContextValue | null>(null);
+
+function buildHourlySeries(calls: DispatchCall[]): HourlyPoint[] {
+  const buckets = new Map<number, number>();
+
+  for (let i = 0; i < 8; i += 1) {
+    buckets.set(i, 0);
+  }
+
+  calls.forEach((call) => {
+    const hour = new Date(call.startedAt).getHours();
+    buckets.set(hour, (buckets.get(hour) ?? 0) + 1);
+  });
+
+  return Array.from(buckets.entries())
+    .sort((a, b) => a[0] - b[0])
+    .slice(-8)
+    .map(([hour, count]) => ({
+      hour: `${String(hour).padStart(2, "0")}:00`,
+      count,
+    }));
+}
+
+function byType(calls: DispatchCall[], type: EmergencyType): number {
+  return calls.filter((call) => call.emergencyType === type).length;
+}
+
+export function DispatchProvider({ children }: { children: ReactNode }) {
+  const [calls, setCalls] = useState<DispatchCall[]>(INITIAL_CALLS);
+  const [selectedCallId, setSelectedCallId] = useState<string | null>(
+    INITIAL_CALLS[0]?.id ?? null
+  );
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setCalls((current) => {
+        const ongoing = current.filter((call) => call.status === "ongoing");
+        if (ongoing.length === 0) {
+          return current;
+        }
+
+        const selected = ongoing[Math.floor(Math.random() * ongoing.length)];
+
+        return current.map((call) => {
+          if (call.id !== selected.id) {
+            return call;
+          }
+
+          const nextTranscript = [
+            ...call.transcript,
+            {
+              id: `t-${Date.now()}`,
+              speaker: Math.random() > 0.6 ? "caller" : "dispatcher",
+              text: randomLiveLine(),
+              timestamp: Date.now(),
+            },
+          ];
+
+          return {
+            ...call,
+            transcript: nextTranscript.slice(-12),
+          };
+        });
+      });
+    }, 6000);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const metrics = useMemo<DashboardMetrics>(() => {
+    const totalCallsToday = calls.length;
+    const ongoingCalls = calls.filter((call) => call.status === "ongoing").length;
+    const dispatchSent = calls.filter((call) => call.status === "dispatch_sent").length;
+    const resolvedCalls = calls.filter((call) => call.status === "resolved").length;
+
+    const sentCalls = calls.filter((call) => call.dispatchSentAt && call.startedAt);
+    const avgTimeToDispatchMins =
+      sentCalls.length === 0
+        ? 0
+        : Math.round(
+            sentCalls.reduce((acc, call) => {
+              const delta = (call.dispatchSentAt ?? call.startedAt) - call.startedAt;
+              return acc + delta / 60000;
+            }, 0) / sentCalls.length
+          );
+
+    const highPriorityCount = calls.filter(
+      (call) => call.priority === "P1" || call.priority === "P2"
+    ).length;
+
+    return {
+      totalCallsToday,
+      ongoingCalls,
+      dispatchSent,
+      resolvedCalls,
+      avgTimeToDispatchMins,
+      highPriorityCount,
+    };
+  }, [calls]);
+
+  const callsByType = useMemo<CallsByType>(
+    () => ({
+      Medical: byType(calls, "Medical"),
+      Fire: byType(calls, "Fire"),
+      Police: byType(calls, "Police"),
+    }),
+    [calls]
+  );
+
+  const callsByHour = useMemo(() => buildHourlySeries(calls), [calls]);
+
+  const selectCall = (callId: string) => {
+    setSelectedCallId(callId);
+  };
+
+  const updateCallStatus = (callId: string, status: CallStatus) => {
+    setCalls((current) =>
+      current.map((call) => {
+        if (call.id !== callId) {
+          return call;
+        }
+
+        if (status === "dispatch_sent") {
+          return {
+            ...call,
+            status,
+            dispatchSentAt: call.dispatchSentAt ?? Date.now(),
+          };
+        }
+
+        if (status === "resolved") {
+          return {
+            ...call,
+            status,
+            resolvedAt: Date.now(),
+            dispatchSentAt: call.dispatchSentAt ?? Date.now(),
+          };
+        }
+
+        return {
+          ...call,
+          status,
+        };
+      })
+    );
+  };
+
+  const updateCallNotes = (callId: string, notes: string) => {
+    setCalls((current) =>
+      current.map((call) => {
+        if (call.id !== callId) {
+          return call;
+        }
+
+        return {
+          ...call,
+          notes,
+        };
+      })
+    );
+  };
+
+  const value: DispatchContextValue = {
+    now,
+    calls,
+    selectedCallId,
+    metrics,
+    callsByType,
+    callsByHour,
+    selectCall,
+    updateCallStatus,
+    updateCallNotes,
+  };
+
+  return <DispatchContext.Provider value={value}>{children}</DispatchContext.Provider>;
+}
+
+export function useDispatchData() {
+  const value = useContext(DispatchContext);
+  if (!value) {
+    throw new Error("useDispatchData must be used inside DispatchProvider");
+  }
+  return value;
+}
+
+export function formatElapsed(startedAt: number, now: number): string {
+  const total = Math.floor((now - startedAt) / 1000);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+export function statusLabel(status: CallStatus): string {
+  if (status === "dispatch_sent") return "Dispatch Sent";
+  if (status === "ongoing") return "Ongoing";
+  return "Resolved";
+}
+
+export function priorityTone(priority: string): string {
+  if (priority === "P1") return "bg-stone-200 text-stone-900 border-stone-400";
+  if (priority === "P2") return "bg-stone-100 text-stone-800 border-stone-300";
+  if (priority === "P3") return "bg-slate-100 text-slate-800 border-slate-300";
+  if (priority === "P4") return "bg-slate-50 text-slate-700 border-slate-300";
+  return "bg-slate-50 text-slate-600 border-slate-300";
+}
+
+export function statusTone(status: CallStatus): string {
+  if (status === "ongoing") return "bg-stone-200 text-stone-900 border-stone-400";
+  if (status === "dispatch_sent") {
+    return "bg-slate-100 text-slate-800 border-slate-300";
+  }
+  return "bg-slate-50 text-slate-700 border-slate-300";
+}
+
+export function sortCalls(calls: DispatchCall[]): DispatchCall[] {
+  return [...calls].sort((a, b) => {
+    const statusRank: Record<CallStatus, number> = {
+      ongoing: 0,
+      dispatch_sent: 1,
+      resolved: 2,
+    };
+
+    const statusDiff = statusRank[a.status] - statusRank[b.status];
+    if (statusDiff !== 0) return statusDiff;
+
+    const priorityDiff = priorityWeight(a.priority) - priorityWeight(b.priority);
+    if (priorityDiff !== 0) return priorityDiff;
+
+    return b.startedAt - a.startedAt;
+  });
+}

--- a/components/dispatcher/mock-data.ts
+++ b/components/dispatcher/mock-data.ts
@@ -1,0 +1,132 @@
+import type { DispatchCall, Priority } from "./types";
+
+const now = Date.now();
+
+function minsAgo(minutes: number): number {
+  return now - minutes * 60 * 1000;
+}
+
+export const INITIAL_CALLS: DispatchCall[] = [
+  {
+    id: "c-1001",
+    phoneNumber: "+1 (415) 555-0198",
+    callerName: "Ava Miller",
+    locationText: "412 Pine St, San Francisco, CA",
+    latitude: 37.7893,
+    longitude: -122.4039,
+    emergencyType: "Medical",
+    priority: "P1",
+    status: "ongoing",
+    startedAt: minsAgo(7),
+    tags: ["unconscious", "not breathing"],
+    urgencyScore: 96,
+    confidence: 0.93,
+    transcript: [
+      { id: "t1", speaker: "dispatcher", text: "911, what is your emergency?", timestamp: minsAgo(7) },
+      { id: "t2", speaker: "caller", text: "My father collapsed and is not responding.", timestamp: minsAgo(6) },
+    ],
+    notes: "CPR guidance provided.",
+  },
+  {
+    id: "c-1002",
+    phoneNumber: "+1 (415) 555-0165",
+    callerName: "Noah Patel",
+    locationText: "89 Howard St, San Francisco, CA",
+    latitude: 37.7884,
+    longitude: -122.3969,
+    emergencyType: "Fire",
+    priority: "P2",
+    status: "dispatch_sent",
+    startedAt: minsAgo(19),
+    dispatchSentAt: minsAgo(14),
+    tags: ["apartment", "smoke", "children inside"],
+    urgencyScore: 89,
+    confidence: 0.88,
+    transcript: [
+      { id: "t3", speaker: "caller", text: "There is smoke in the hallway and alarms are going off.", timestamp: minsAgo(19) },
+    ],
+    notes: "Engine 4 and Ladder 2 en route.",
+  },
+  {
+    id: "c-1003",
+    phoneNumber: "+1 (628) 555-0121",
+    callerName: "Olivia Chen",
+    locationText: "16th St & Mission St, San Francisco, CA",
+    latitude: 37.7651,
+    longitude: -122.4197,
+    emergencyType: "Police",
+    priority: "P3",
+    status: "ongoing",
+    startedAt: minsAgo(5),
+    tags: ["assault", "suspect fleeing"],
+    urgencyScore: 76,
+    confidence: 0.82,
+    transcript: [
+      { id: "t4", speaker: "caller", text: "Someone just attacked a man and ran toward Mission.", timestamp: minsAgo(4) },
+    ],
+    notes: "Requesting additional witness details.",
+  },
+  {
+    id: "c-1004",
+    phoneNumber: "+1 (415) 555-0114",
+    callerName: "Ethan Brooks",
+    locationText: "Folsom St, San Francisco, CA",
+    latitude: 37.783,
+    longitude: -122.3995,
+    emergencyType: "Medical",
+    priority: "P2",
+    status: "resolved",
+    startedAt: minsAgo(52),
+    dispatchSentAt: minsAgo(45),
+    resolvedAt: minsAgo(21),
+    tags: ["allergic reaction", "epi-pen used"],
+    urgencyScore: 70,
+    confidence: 0.91,
+    transcript: [],
+    notes: "Caller stable when EMS arrived.",
+  },
+  {
+    id: "c-1005",
+    phoneNumber: "+1 (510) 555-0182",
+    callerName: "Mia Johnson",
+    locationText: "3rd St, San Francisco, CA",
+    latitude: 37.7753,
+    longitude: -122.3883,
+    emergencyType: "Fire",
+    priority: "P4",
+    status: "ongoing",
+    startedAt: minsAgo(2),
+    tags: ["trash fire", "no injuries"],
+    urgencyScore: 41,
+    confidence: 0.78,
+    transcript: [
+      { id: "t5", speaker: "caller", text: "Small fire near a dumpster behind the store.", timestamp: minsAgo(1) },
+    ],
+    notes: "",
+  },
+];
+
+export function priorityWeight(priority: Priority): number {
+  const weights: Record<Priority, number> = {
+    P1: 1,
+    P2: 2,
+    P3: 3,
+    P4: 4,
+    P5: 5,
+  };
+  return weights[priority];
+}
+
+const LIVE_TRANSCRIPT_SNIPPETS = [
+  "Can you confirm the nearest cross street?",
+  "Help is on the way, stay with me.",
+  "Is the patient breathing right now?",
+  "Do you see any active flames?",
+  "Are you in a safe location?",
+  "Can you describe the suspect clothing?",
+];
+
+export function randomLiveLine(): string {
+  const index = Math.floor(Math.random() * LIVE_TRANSCRIPT_SNIPPETS.length);
+  return LIVE_TRANSCRIPT_SNIPPETS[index];
+}

--- a/components/dispatcher/overview-page.tsx
+++ b/components/dispatcher/overview-page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Flame, HeartPulse, ShieldAlert, Timer, TrendingUp } from "lucide-react";
+import { priorityTone, sortCalls, useDispatchData } from "./dispatch-provider";
+import {
+  Map,
+  MapControls,
+  MapMarker,
+  MarkerContent,
+  MapPopup,
+  MarkerTooltip,
+  type MapRef,
+} from "@/components/ui/map";
+
+function MetricCard({
+  label,
+  value,
+  delta,
+  tone,
+}: {
+  label: string;
+  value: string;
+  delta: string;
+  tone: string;
+}) {
+  return (
+    <article className="relative overflow-hidden rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className={`pointer-events-none absolute inset-x-0 top-0 h-1 ${tone}`} />
+      <p className="text-[11px] uppercase tracking-[0.16em] text-slate-500">{label}</p>
+      <p className="mt-2 text-3xl font-semibold text-slate-900">{value}</p>
+      <p className="mt-2 flex items-center gap-1 text-xs text-slate-500">
+        <TrendingUp className="h-3 w-3 text-slate-500" />
+        {delta}
+      </p>
+    </article>
+  );
+}
+
+function PriorityMap() {
+  const { calls } = useDispatchData();
+  const mapRef = useRef<MapRef | null>(null);
+  const [activeCallId, setActiveCallId] = useState<string | null>(null);
+
+  const center = useMemo<[number, number]>(() => {
+    if (calls.length === 0) return [-122.4039, 37.7893];
+
+    const total = calls.reduce(
+      (acc, call) => {
+        acc.lat += call.latitude;
+        acc.lng += call.longitude;
+        return acc;
+      },
+      { lat: 0, lng: 0 }
+    );
+
+    return [total.lng / calls.length, total.lat / calls.length];
+  }, [calls]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || calls.length === 0) return;
+
+    if (calls.length === 1) {
+      map.flyTo({
+        center: [calls[0].longitude, calls[0].latitude],
+        zoom: 13.5,
+        duration: 500,
+      });
+      return;
+    }
+
+    const lats = calls.map((c) => c.latitude);
+    const lngs = calls.map((c) => c.longitude);
+
+    map.fitBounds(
+      [
+        [Math.min(...lngs), Math.min(...lats)],
+        [Math.max(...lngs), Math.max(...lats)],
+      ],
+      {
+        padding: 56,
+        maxZoom: 14,
+        duration: 600,
+      }
+    );
+  }, [calls]);
+
+  const activeCall = calls.find((call) => call.id === activeCallId) ?? null;
+
+  const markerTone = (priority: string) => {
+    if (priority === "P1") return "bg-black";
+    if (priority === "P2") return "bg-slate-700";
+    if (priority === "P3") return "bg-slate-600";
+    if (priority === "P4") return "bg-slate-500";
+    return "bg-slate-400";
+  };
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="mb-4 flex items-center justify-between border-b border-slate-200 pb-3">
+        <h2 className="text-xs uppercase tracking-[0.16em] text-slate-700">Incident Heat Map</h2>
+        <span className="text-xs text-slate-500">Priority Markers</span>
+      </div>
+
+      <div className="h-[22rem] overflow-hidden rounded-lg border border-slate-200">
+        <Map
+          ref={mapRef}
+          theme="light"
+          className="h-full w-full"
+          center={center}
+          zoom={12.4}
+          maxZoom={17}
+          minZoom={10}
+        >
+          {calls.map((call) => (
+            <MapMarker
+              key={call.id}
+              longitude={call.longitude}
+              latitude={call.latitude}
+              onClick={() => setActiveCallId(call.id)}
+            >
+              <MarkerContent>
+                <div
+                  className={`h-5 w-5 rounded-full ring-2 ring-white shadow-[0_4px_14px_rgba(15,23,42,.35)] ${markerTone(call.priority)}`}
+                />
+              </MarkerContent>
+              <MarkerTooltip className="border border-slate-200 bg-white text-slate-800 shadow">
+                <p className="text-[11px] font-semibold">{call.priority}</p>
+                <p className="text-[11px]">{call.emergencyType}</p>
+                <p className="text-[11px] text-slate-500">{call.locationText}</p>
+              </MarkerTooltip>
+            </MapMarker>
+          ))}
+
+          {activeCall ? (
+            <MapPopup
+              longitude={activeCall.longitude}
+              latitude={activeCall.latitude}
+              onClose={() => setActiveCallId(null)}
+              closeButton
+              className="w-56 border border-slate-200 bg-white text-slate-800 shadow"
+            >
+              <p className="text-xs font-semibold text-slate-800">
+                {activeCall.emergencyType} · {activeCall.priority}
+              </p>
+              <p className="mt-1 text-xs text-slate-600">{activeCall.locationText}</p>
+              <p className="mt-1 text-xs text-slate-500">{activeCall.phoneNumber}</p>
+            </MapPopup>
+          ) : null}
+
+          <MapControls
+            position="top-right"
+            showZoom
+            showCompass
+            showFullscreen
+            className="[&_button]:text-slate-800 [&_button]:bg-white/95 [&_button:hover]:bg-slate-100 [&_.border-border]:border-slate-300 [&_button:not(:last-child)]:border-slate-300 [&_.bg-background]:bg-white/95"
+          />
+        </Map>
+      </div>
+    </section>
+  );
+}
+
+function PulseRow({
+  name,
+  value,
+  total,
+  icon,
+}: {
+  name: string;
+  value: number;
+  total: number;
+  icon: ReactNode;
+}) {
+  const width = Math.max((value / total) * 100, 8);
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between text-xs text-slate-700">
+        <span className="inline-flex items-center gap-2">
+          {icon}
+          {name}
+        </span>
+        <span className="font-semibold text-slate-900">{value}</span>
+      </div>
+      <div className="h-2 rounded bg-slate-200">
+        <div className="h-2 rounded bg-slate-500" style={{ width: `${width}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function ChannelPulse() {
+  const { callsByType } = useDispatchData();
+  const total = callsByType.Medical + callsByType.Fire + callsByType.Police || 1;
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="border-b border-slate-200 pb-3 text-xs uppercase tracking-[0.16em] text-slate-700">
+        Channel Pulse
+      </h2>
+
+      <div className="mt-4 space-y-4">
+        <PulseRow
+          name="Medical"
+          value={callsByType.Medical}
+          total={total}
+          icon={<HeartPulse className="h-3.5 w-3.5 text-slate-500" />}
+        />
+        <PulseRow
+          name="Fire"
+          value={callsByType.Fire}
+          total={total}
+          icon={<Flame className="h-3.5 w-3.5 text-slate-500" />}
+        />
+        <PulseRow
+          name="Police"
+          value={callsByType.Police}
+          total={total}
+          icon={<ShieldAlert className="h-3.5 w-3.5 text-slate-500" />}
+        />
+      </div>
+    </section>
+  );
+}
+
+function CallsByHourChart() {
+  const { callsByHour } = useDispatchData();
+  const maxCount = Math.max(...callsByHour.map((point) => point.count), 1);
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="border-b border-slate-200 pb-3 text-xs uppercase tracking-[0.16em] text-slate-700">
+        Traffic Volume
+      </h2>
+      <div className="mt-4 grid grid-cols-8 gap-2">
+        {callsByHour.map((point) => (
+          <div key={point.hour} className="flex flex-col items-center gap-2">
+            <div className="flex h-24 w-full items-end rounded bg-slate-100 p-1">
+              <div
+                className="w-full rounded bg-slate-600"
+                style={{ height: `${Math.max((point.count / maxCount) * 100, 6)}%` }}
+              />
+            </div>
+            <span className="text-[10px] text-slate-500">{point.hour}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RecentCalls() {
+  const { calls } = useDispatchData();
+  const visible = useMemo(() => sortCalls(calls).slice(0, 6), [calls]);
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="border-b border-slate-200 pb-3 text-xs uppercase tracking-[0.16em] text-slate-700">
+        Active Incident Feed
+      </h2>
+      <div className="mt-4 space-y-3">
+        {visible.map((call) => (
+          <article
+            key={call.id}
+            className="flex min-h-16 items-center justify-between rounded-lg border border-slate-200 bg-slate-50 p-3 transition hover:border-slate-400"
+          >
+            <div>
+              <p className="text-sm text-slate-900">{call.locationText}</p>
+              <p className="text-xs text-slate-500">
+                {call.emergencyType} • {call.phoneNumber}
+              </p>
+            </div>
+            <span className={`rounded border px-2 py-1 text-xs font-semibold ${priorityTone(call.priority)}`}>
+              {call.priority}
+            </span>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function OverviewPage() {
+  const { metrics } = useDispatchData();
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <MetricCard
+          label="Total Calls Today"
+          value={String(metrics.totalCallsToday)}
+          delta="+8% from 1h ago"
+          tone="bg-slate-400"
+        />
+        <MetricCard
+          label="Ongoing Calls"
+          value={String(metrics.ongoingCalls)}
+          delta="Real-time queue"
+          tone="bg-slate-500"
+        />
+        <MetricCard
+          label="Dispatch Sent"
+          value={String(metrics.dispatchSent)}
+          delta="Units actively en route"
+          tone="bg-slate-500"
+        />
+        <MetricCard
+          label="Resolved Calls"
+          value={String(metrics.resolvedCalls)}
+          delta="Closed in this cycle"
+          tone="bg-slate-400"
+        />
+        <MetricCard
+          label="Average Dispatch Time"
+          value={`${metrics.avgTimeToDispatchMins} min`}
+          delta="Target: < 5 min"
+          tone="bg-slate-500"
+        />
+        <MetricCard
+          label="High Priority (P1/P2)"
+          value={String(metrics.highPriorityCount)}
+          delta="Monitor escalation risk"
+          tone="bg-slate-600"
+        />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <PriorityMap />
+        <div className="space-y-6">
+          <ChannelPulse />
+          <CallsByHourChart />
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <p className="text-xs uppercase tracking-[0.16em] text-slate-500">System Clock</p>
+            <p className="mt-2 inline-flex items-center gap-2 text-2xl font-semibold text-slate-900">
+              <Timer className="h-5 w-5 text-slate-600" />
+              UTC-08 Operational Window
+            </p>
+            <p className="mt-2 text-xs text-slate-500">
+              All events synchronized to call intake timestamps.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <RecentCalls />
+    </div>
+  );
+}

--- a/components/dispatcher/queue-page.tsx
+++ b/components/dispatcher/queue-page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MapPin, NotebookPen } from "lucide-react";
+import {
+  formatElapsed,
+  priorityTone,
+  sortCalls,
+  statusLabel,
+  statusTone,
+  useDispatchData,
+} from "./dispatch-provider";
+import type { DispatchCall } from "./types";
+
+type SortKey = "priority" | "elapsed" | "status";
+
+function mapUrl(locationText: string, lat: number, lng: number): string {
+  const query = encodeURIComponent(`${locationText} ${lat},${lng}`);
+  return `https://maps.google.com/?q=${query}`;
+}
+
+function QueueTable() {
+  const { calls, now, selectedCallId, selectCall } = useDispatchData();
+  const [sortKey, setSortKey] = useState<SortKey>("priority");
+  const [desc, setDesc] = useState(false);
+
+  const rows = useMemo(() => {
+    const sorted = sortCalls(calls);
+
+    const sortedByKey = [...sorted].sort((a, b) => {
+      if (sortKey === "elapsed") return now - a.startedAt - (now - b.startedAt);
+      if (sortKey === "status") return statusLabel(a.status).localeCompare(statusLabel(b.status));
+      return a.priority.localeCompare(b.priority);
+    });
+
+    return desc ? sortedByKey.reverse() : sortedByKey;
+  }, [calls, now, sortKey, desc]);
+
+  const selectSort = (next: SortKey) => {
+    if (next === sortKey) {
+      setDesc((value) => !value);
+      return;
+    }
+    setSortKey(next);
+    setDesc(false);
+  };
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-4 py-3">
+        <h2 className="text-xs uppercase tracking-[0.16em] text-slate-700">Current Queue</h2>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-[11px] uppercase tracking-[0.12em] text-slate-500">
+            <tr>
+              <th className="px-4 py-4">Phone Number</th>
+              <th className="px-4 py-4">
+                <button onClick={() => selectSort("priority")} className="h-8 rounded px-2 hover:bg-slate-100 hover:text-slate-800">
+                  Priority
+                </button>
+              </th>
+              <th className="px-4 py-4">
+                <button onClick={() => selectSort("status")} className="h-8 rounded px-2 hover:bg-slate-100 hover:text-slate-800">
+                  Status
+                </button>
+              </th>
+              <th className="px-4 py-4">
+                <button onClick={() => selectSort("elapsed")} className="h-8 rounded px-2 hover:bg-slate-100 hover:text-slate-800">
+                  Elapsed
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((call) => (
+              <tr
+                key={call.id}
+                className={`cursor-pointer border-t border-slate-200 transition hover:bg-slate-50 ${
+                  selectedCallId === call.id ? "bg-slate-100" : ""
+                }`}
+                onClick={() => selectCall(call.id)}
+              >
+                <td className="px-4 py-4 text-slate-700">{call.phoneNumber}</td>
+                <td className="px-4 py-4">
+                  <span className={`rounded border px-2 py-1 text-xs font-semibold ${priorityTone(call.priority)}`}>
+                    {call.priority}
+                  </span>
+                </td>
+                <td className="px-4 py-4">
+                  <span className={`rounded border px-2 py-1 text-xs ${statusTone(call.status)}`}>
+                    {statusLabel(call.status)}
+                  </span>
+                </td>
+                <td className="px-4 py-4 font-mono text-slate-600">{formatElapsed(call.startedAt, now)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function Transcript({ call }: { call: DispatchCall }) {
+  if (call.transcript.length === 0) {
+    return (
+      <div className="rounded border border-slate-200 bg-slate-50 p-3 text-xs text-slate-500">
+        No transcript lines yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-h-52 space-y-2 overflow-y-auto rounded border border-slate-200 bg-slate-50 p-3">
+      {call.transcript.map((line) => (
+        <div key={line.id} className="text-xs leading-relaxed">
+          <span className={`mr-2 font-semibold ${line.speaker === "caller" ? "text-slate-700" : "text-slate-600"}`}>
+            {line.speaker === "caller" ? "CALLER" : "DISPATCH"}
+          </span>
+          <span className="text-slate-700">{line.text}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DetailPanel() {
+  const { calls, selectedCallId, updateCallStatus, updateCallNotes, now } = useDispatchData();
+  const call = calls.find((item) => item.id === selectedCallId) ?? null;
+
+  if (!call) {
+    return (
+      <aside className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-500 shadow-sm">
+        Select a call to see details.
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="space-y-5 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">{call.callerName}</h3>
+          <p className="text-xs text-slate-500">{call.phoneNumber}</p>
+        </div>
+        <span className={`rounded border px-2 py-1 text-xs font-semibold ${priorityTone(call.priority)}`}>
+          {call.priority}
+        </span>
+      </div>
+
+      <div className="grid gap-3 border-t border-slate-200 pt-4 text-sm">
+        <p className="text-slate-700">{call.locationText}</p>
+        <a
+          href={mapUrl(call.locationText, call.latitude, call.longitude)}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-slate-700 underline"
+        >
+          <MapPin className="h-3.5 w-3.5" />
+          Open map link
+        </a>
+        <p className="text-slate-500">Type: {call.emergencyType}</p>
+        <p className="text-slate-500">Elapsed: {formatElapsed(call.startedAt, now)}</p>
+      </div>
+
+      <div className="border-t border-slate-200 pt-4">
+        <p className="mb-2 text-xs uppercase tracking-[0.14em] text-slate-500">Extracted Information</p>
+        <div className="flex flex-wrap gap-2">
+          {call.tags.map((tag) => (
+            <span key={tag} className="rounded-full border border-slate-300 bg-slate-50 px-2 py-1 text-xs text-slate-700">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 border-t border-slate-200 pt-4 text-sm">
+        <div className="rounded border border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs text-slate-500">Urgency Score</p>
+          <p className="mt-1 text-lg font-semibold text-slate-900">{call.urgencyScore}</p>
+        </div>
+        <div className="rounded border border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs text-slate-500">Confidence</p>
+          <p className="mt-1 text-lg font-semibold text-slate-900">{Math.round(call.confidence * 100)}%</p>
+        </div>
+      </div>
+
+      <div className="border-t border-slate-200 pt-4">
+        <p className="mb-2 text-xs uppercase tracking-[0.14em] text-slate-500">Live Transcript</p>
+        <Transcript call={call} />
+      </div>
+
+      <div className="flex gap-2 border-t border-slate-200 pt-4">
+        <button
+          className="h-10 rounded border border-emerald-200 bg-emerald-50 px-3 text-sm text-emerald-700 hover:bg-emerald-100"
+          onClick={() => updateCallStatus(call.id, "dispatch_sent")}
+        >
+          Dispatch Sent
+        </button>
+        <button
+          className="h-10 rounded border border-slate-300 bg-slate-100 px-3 text-sm text-slate-700 hover:bg-slate-200"
+          onClick={() => updateCallStatus(call.id, "resolved")}
+        >
+          Resolved
+        </button>
+      </div>
+
+      <div className="border-t border-slate-200 pt-4">
+        <label htmlFor="notes" className="mb-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-slate-500">
+          <NotebookPen className="h-3.5 w-3.5" />
+          Notes
+        </label>
+        <textarea
+          id="notes"
+          value={call.notes}
+          onChange={(event) => updateCallNotes(call.id, event.target.value)}
+          className="h-24 w-full rounded border border-slate-300 bg-slate-50 p-2 text-sm text-slate-800 outline-none ring-offset-0 focus:border-slate-500"
+          placeholder="Dispatcher notes..."
+        />
+      </div>
+    </aside>
+  );
+}
+
+export function QueuePage() {
+  return (
+    <div className="grid gap-6 xl:grid-cols-[1.6fr_1fr]">
+      <QueueTable />
+      <DetailPanel />
+    </div>
+  );
+}

--- a/components/dispatcher/types.ts
+++ b/components/dispatcher/types.ts
@@ -1,0 +1,32 @@
+export type Priority = "P1" | "P2" | "P3" | "P4" | "P5";
+
+export type CallStatus = "ongoing" | "dispatch_sent" | "resolved";
+
+export type EmergencyType = "Medical" | "Fire" | "Police";
+
+export interface TranscriptLine {
+  id: string;
+  speaker: "caller" | "dispatcher";
+  text: string;
+  timestamp: number;
+}
+
+export interface DispatchCall {
+  id: string;
+  phoneNumber: string;
+  callerName: string;
+  locationText: string;
+  latitude: number;
+  longitude: number;
+  emergencyType: EmergencyType;
+  priority: Priority;
+  status: CallStatus;
+  startedAt: number;
+  dispatchSentAt?: number;
+  resolvedAt?: number;
+  tags: string[];
+  urgencyScore: number;
+  confidence: number;
+  transcript: TranscriptLine[];
+  notes: string;
+}

--- a/components/ui/call-interface.tsx
+++ b/components/ui/call-interface.tsx
@@ -3,140 +3,69 @@
 import { useAtomsCall, type CallStatus } from "@/hooks/use-atoms-call";
 import { useEffect, useRef } from "react";
 
-/* ─── Design System ───
- * Aesthetic: Dark, utilitarian dispatch terminal
- * Typography: Geist Sans (headings) + Geist Mono (data/timestamps)
- * Palette: Neutral-950 base, red-600 primary (emergency), blue-500 caller accent
- * Motion: Purposeful — waveform bars, message fade-in, breathing CTA glow
- * Layout: Single-column, centered, max-w-sm for focused attention
- * ─── */
-
-function formatTime(timestamp: number): string {
-  const date = new Date(timestamp);
-  return date.toLocaleTimeString("en-US", {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-}
-
-/* ─── Status Indicator ─── */
 function StatusIndicator({ status }: { status: CallStatus }) {
-  const config: Record<
-    CallStatus,
-    { color: string; pulse: boolean; label: string }
-  > = {
-    idle: { color: "bg-neutral-500", pulse: false, label: "Standby" },
-    connecting: { color: "bg-amber-400", pulse: true, label: "Connecting" },
-    waiting_for_agent: {
-      color: "bg-amber-400",
-      pulse: true,
-      label: "Routing",
-    },
-    active: { color: "bg-emerald-400", pulse: true, label: "Active" },
+  const config: Record<CallStatus, { color: string; pulse: boolean; label: string }> = {
+    idle: { color: "bg-gray-400", pulse: false, label: "Standby" },
+    connecting: { color: "bg-yellow-400", pulse: true, label: "Connecting" },
+    waiting_for_agent: { color: "bg-yellow-400", pulse: true, label: "Routing" },
+    active: { color: "bg-green-500", pulse: true, label: "Active" },
     error: { color: "bg-red-500", pulse: false, label: "Error" },
-    ended: { color: "bg-neutral-500", pulse: false, label: "Ended" },
+    ended: { color: "bg-gray-400", pulse: false, label: "Ended" },
   };
 
   const { color, pulse, label } = config[status];
 
   return (
-    <div className="flex items-center gap-2.5">
-      <span className="relative flex h-2.5 w-2.5">
+    <div className="flex items-center gap-2">
+      <span className="relative flex h-3 w-3">
         {pulse && (
           <span
-            className={`absolute inline-flex h-full w-full rounded-full opacity-60 animate-ring-expand ${color}`}
+            className={`absolute inline-flex h-full w-full animate-ping rounded-full ${color} opacity-75`}
           />
         )}
         <span
-          className={`relative inline-flex h-2.5 w-2.5 rounded-full ${color}`}
+          className={`relative inline-flex h-3 w-3 rounded-full ${color}`}
         />
       </span>
-      <span className="text-[11px] font-semibold uppercase tracking-[0.15em] text-neutral-400 font-mono">
+      <span className="text-sm font-medium uppercase tracking-wider text-neutral-400">
         {label}
       </span>
     </div>
   );
 }
 
-/* ─── Waveform Visualizer ─── */
 function WaveformVisualizer({ active }: { active: boolean }) {
-  const barCount = 28;
+  const bars = Array.from({ length: 24 }).map((_, i) => ({
+    height: `${12 + ((i * 17) % 44)}px`,
+    duration: `${320 + ((i * 53) % 390)}ms`,
+    delay: `${i * 50}ms`,
+  }));
 
   return (
-    <div
-      className="flex items-center justify-center gap-[3px] h-14"
-      role="img"
-      aria-label={active ? "Dispatcher is speaking" : "Waiting for audio"}
-    >
-      {Array.from({ length: barCount }).map((_, i) => {
-        // Create a natural wave shape: taller in the center, shorter at edges
-        const center = (barCount - 1) / 2;
-        const dist = Math.abs(i - center) / center; // 0 at center, 1 at edges
-        const maxH = active ? 40 - dist * 26 : 4;
-        const minH = active ? 6 : 4;
-
-        return (
-          <div
-            key={i}
-            className={`w-[3px] rounded-full origin-center transition-colors duration-200 ${
-              active
-                ? "bg-red-500 animate-waveform-bar"
-                : "bg-neutral-700/60"
-            }`}
-            style={{
-              height: active ? undefined : `${minH}px`,
-              minHeight: `${minH}px`,
-              maxHeight: `${maxH}px`,
-              animationDuration: active
-                ? `${600 + Math.sin(i * 0.7) * 250}ms`
-                : undefined,
-              animationDelay: active ? `${i * 35}ms` : undefined,
-            }}
-          />
-        );
-      })}
+    <div className="flex items-center justify-center gap-1 h-16">
+      {bars.map((bar, i) => (
+        <div
+          key={i}
+          className={`w-1 rounded-full transition-all duration-150 ${
+            active
+              ? "bg-red-500/80 animate-pulse"
+              : "bg-neutral-700 h-2"
+          }`}
+          style={
+            active
+              ? {
+                  height: bar.height,
+                  animationDelay: bar.delay,
+                  animationDuration: bar.duration,
+                }
+              : undefined
+          }
+        />
+      ))}
     </div>
   );
 }
 
-/* ─── Sender Badge ─── */
-function SenderBadge({ sender }: { sender: "caller" | "dispatcher" }) {
-  const isDispatcher = sender === "dispatcher";
-  return (
-    <span
-      className={`inline-flex items-center rounded-sm px-1.5 py-px text-[10px] font-bold uppercase tracking-[0.1em] font-mono leading-none ${
-        isDispatcher
-          ? "bg-red-500/15 text-red-400 ring-1 ring-red-500/20"
-          : "bg-blue-500/15 text-blue-400 ring-1 ring-blue-500/20"
-      }`}
-    >
-      {isDispatcher ? "DISP" : "YOU"}
-    </span>
-  );
-}
-
-/* ─── Phone Icon ─── */
-function PhoneIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      strokeWidth={2}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
-      />
-    </svg>
-  );
-}
-
-/* ─── Main Interface ─── */
 export function CallInterface() {
   const {
     status,
@@ -144,8 +73,6 @@ export function CallInterface() {
     isAgentSpeaking,
     isMuted,
     transcript,
-    interimTranscript,
-    isSpeechRecognitionSupported,
     startCall,
     endCall,
     toggleMute,
@@ -154,239 +81,163 @@ export function CallInterface() {
 
   const transcriptEndRef = useRef<HTMLDivElement>(null);
 
+  // Auto-scroll transcript
   useEffect(() => {
     transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [transcript, interimTranscript]);
+  }, [transcript]);
 
   const isCallActive = status === "active" || status === "waiting_for_agent";
   const isConnecting = status === "connecting";
-  const showTranscript = transcript.length > 0 || interimTranscript;
 
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-neutral-950 p-4 selection:bg-red-500/30">
-      <div className="w-full max-w-sm space-y-5">
-        {/* ── Header ── */}
-        <header className="text-center space-y-1">
-          <h1 className="text-5xl font-black tracking-tight text-white leading-none">
+    <div className="flex min-h-screen items-center justify-center bg-neutral-950 p-4 font-sans">
+      <div className="w-full max-w-md space-y-6">
+        {/* Header */}
+        <div className="text-center">
+          <h1 className="text-5xl font-black tracking-tight text-white">
             911
           </h1>
-          <p className="text-[11px] font-medium uppercase tracking-[0.35em] text-neutral-500">
+          <p className="mt-1 text-sm font-medium uppercase tracking-[0.3em] text-neutral-500">
             Emergency Dispatch
           </p>
-        </header>
+        </div>
 
-        {/* ── Main Card ── */}
-        <section className="rounded-2xl border border-neutral-800/80 bg-neutral-900/80 backdrop-blur-sm p-5 shadow-2xl shadow-black/40">
+        {/* Main Card */}
+        <div className="rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl shadow-red-950/10">
           {/* Status Bar */}
-          <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center justify-between mb-6">
             <StatusIndicator status={status} />
-            <span className="text-[11px] text-neutral-500 font-mono tracking-wide">
+            <span className="text-xs text-neutral-500 font-mono">
               {statusMessage}
             </span>
           </div>
 
           {/* Waveform / Visual */}
-          <div className="mb-5 rounded-xl border border-neutral-800/60 bg-neutral-950/80 p-4">
+          <div className="mb-6 rounded-xl border border-neutral-800 bg-neutral-950 p-4">
             {isCallActive || isConnecting ? (
               <WaveformVisualizer active={isAgentSpeaking} />
             ) : (
-              <div className="flex h-14 items-center justify-center">
-                <p className="text-sm text-neutral-600 font-light">
+              <div className="flex h-16 items-center justify-center">
+                <p className="text-sm text-neutral-600">
                   {status === "idle"
                     ? "Press the button below to call"
                     : status === "ended"
-                      ? "Call has ended"
-                      : "An error occurred"}
+                    ? "Call has ended"
+                    : "An error occurred"}
                 </p>
               </div>
             )}
           </div>
 
-          {/* Error */}
+          {/* Error Display */}
           {error && (
-            <div className="mb-4 rounded-lg border border-red-900/40 bg-red-950/30 px-3.5 py-2.5">
-              <p className="text-xs text-red-400 leading-relaxed">{error}</p>
+            <div className="mb-4 rounded-lg border border-red-900/50 bg-red-950/30 p-3">
+              <p className="text-sm text-red-400">{error}</p>
             </div>
           )}
 
-          {/* Speech Recognition Warning */}
-          {isCallActive && !isSpeechRecognitionSupported && (
-            <div className="mb-4 rounded-lg border border-amber-900/40 bg-amber-950/20 px-3.5 py-2.5">
-              <p className="text-[11px] text-amber-400/80 leading-relaxed">
-                Your browser does not support speech recognition. Caller
-                messages will not appear in the transcript. Use Chrome or Edge
-                for full support.
-              </p>
-            </div>
-          )}
-
-          {/* ── Call Controls ── */}
-          <div className="flex items-center justify-center gap-5 pt-1">
+          {/* Call Controls */}
+          <div className="flex items-center justify-center gap-4">
             {!isCallActive && !isConnecting ? (
-              /* Call Button */
               <button
                 onClick={startCall}
-                className="group relative flex h-[72px] w-[72px] items-center justify-center rounded-full bg-red-600 text-white transition-all duration-300 hover:bg-red-500 hover:scale-105 active:scale-95 animate-glow-breathe focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
-                aria-label="Start emergency call"
+                className="group relative flex h-20 w-20 items-center justify-center rounded-full bg-red-600 text-white shadow-lg shadow-red-600/30 transition-all hover:bg-red-500 hover:shadow-red-500/40 hover:scale-105 active:scale-95"
               >
-                <PhoneIcon className="h-7 w-7" />
-                <span className="absolute -bottom-7 text-[11px] font-medium text-neutral-500 group-hover:text-red-400 transition-colors">
+                {/* Phone icon */}
+                <svg
+                  className="h-8 w-8"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+                  />
+                </svg>
+                <span className="absolute -bottom-7 text-xs font-medium text-neutral-400 group-hover:text-red-400">
                   Call 911
                 </span>
               </button>
             ) : (
               <>
-                {/* Mute */}
+                {/* Mute Button */}
                 <button
                   onClick={toggleMute}
                   disabled={status !== "active"}
-                  aria-label={isMuted ? "Unmute microphone" : "Mute microphone"}
-                  className={`flex h-12 w-12 items-center justify-center rounded-full border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 ${
+                  className={`flex h-14 w-14 items-center justify-center rounded-full border transition-all ${
                     isMuted
-                      ? "border-amber-600/60 bg-amber-600/15 text-amber-400"
-                      : "border-neutral-700/60 bg-neutral-800/60 text-neutral-400 hover:border-neutral-600 hover:text-neutral-200"
-                  } disabled:opacity-30 disabled:cursor-not-allowed`}
+                      ? "border-yellow-600 bg-yellow-600/20 text-yellow-400"
+                      : "border-neutral-700 bg-neutral-800 text-neutral-300 hover:border-neutral-600 hover:text-white"
+                  } disabled:opacity-40 disabled:cursor-not-allowed`}
                 >
                   {isMuted ? (
-                    <svg
-                      className="h-[18px] w-[18px]"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"
-                      />
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"
-                      />
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2" />
                     </svg>
                   ) : (
-                    <svg
-                      className="h-[18px] w-[18px]"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
-                      />
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
                     </svg>
                   )}
                 </button>
 
-                {/* End Call */}
+                {/* End Call Button */}
                 <button
                   onClick={endCall}
-                  aria-label="End call"
-                  className="flex h-14 w-14 items-center justify-center rounded-full bg-red-600 text-white shadow-lg shadow-red-900/40 transition-all duration-200 hover:bg-red-500 hover:scale-105 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+                  className="flex h-16 w-16 items-center justify-center rounded-full bg-red-600 text-white shadow-lg shadow-red-600/30 transition-all hover:bg-red-500 hover:scale-105 active:scale-95"
                 >
-                  <PhoneIcon className="h-5 w-5 rotate-[135deg]" />
+                  <svg className="h-6 w-6 rotate-[135deg]" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+                    />
+                  </svg>
                 </button>
               </>
             )}
           </div>
-        </section>
+        </div>
 
-        {/* ── Live Transcript ── */}
-        {showTranscript && (
-          <section
-            className="rounded-2xl border border-neutral-800/80 bg-neutral-900/80 backdrop-blur-sm shadow-2xl shadow-black/30 overflow-hidden"
-            aria-label="Live call transcript"
-          >
-            {/* Transcript Header */}
-            <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-800/60">
-              <div className="flex items-center gap-2">
-                <span className="relative flex h-2 w-2">
-                  <span className="absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75 animate-ping" />
-                  <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
-                </span>
-                <h2 className="text-[11px] font-semibold uppercase tracking-[0.15em] text-neutral-400">
-                  Live Transcript
-                </h2>
-              </div>
-              <span className="text-[10px] font-mono text-neutral-600 tabular-nums">
-                {transcript.length}{" "}
-                {transcript.length === 1 ? "msg" : "msgs"}
-              </span>
+        {/* Live Transcript */}
+        {transcript.length > 0 && (
+          <div className="rounded-2xl border border-neutral-800 bg-neutral-900 p-4 shadow-2xl">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="h-2 w-2 rounded-full bg-red-500 animate-pulse" />
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-neutral-400">
+                Live Transcript
+              </h2>
             </div>
-
-            {/* Messages */}
-            <div className="max-h-80 overflow-y-auto px-3 py-2 space-y-1.5 scrollbar-dispatch">
-              {transcript.map((msg, index) => {
-                const isDispatcher = msg.sender === "dispatcher";
-
-                return (
-                  <div
-                    key={msg.id}
-                    className="animate-fade-in-up"
-                    style={{ animationDelay: `${Math.min(index * 20, 100)}ms` }}
+            <div className="max-h-64 overflow-y-auto space-y-3 pr-1 scrollbar-thin">
+              {transcript.map((msg) => (
+                <div key={msg.id} className="flex gap-3">
+                  <span
+                    className={`mt-0.5 shrink-0 text-xs font-bold uppercase tracking-wider ${
+                      msg.sender === "dispatcher"
+                        ? "text-red-400"
+                        : "text-blue-400"
+                    }`}
                   >
-                    <div
-                      className={`group relative rounded-lg px-3 py-2.5 transition-colors duration-150 ${
-                        isDispatcher
-                          ? "border-l-2 border-red-500/50 bg-red-950/15 hover:bg-red-950/25"
-                          : "border-l-2 border-blue-500/50 bg-blue-950/15 hover:bg-blue-950/25"
-                      }`}
-                    >
-                      {/* Top row: badge + timestamp */}
-                      <div className="flex items-center justify-between mb-1.5">
-                        <SenderBadge sender={msg.sender} />
-                        <span className="text-[10px] font-mono text-neutral-600 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                          {formatTime(msg.timestamp)}
-                        </span>
-                      </div>
-                      {/* Message text */}
-                      <p
-                        className={`text-[13px] leading-relaxed ${
-                          isDispatcher
-                            ? "text-neutral-200"
-                            : "text-neutral-300"
-                        }`}
-                      >
-                        {msg.text}
-                      </p>
-                    </div>
-                  </div>
-                );
-              })}
-
-              {/* Interim transcript — the caller's in-progress speech */}
-              {interimTranscript && (
-                <div className="animate-fade-in-up">
-                  <div className="rounded-lg border-l-2 border-blue-500/25 bg-blue-950/8 px-3 py-2.5">
-                    <div className="flex items-center mb-1.5">
-                      <span className="inline-flex items-center rounded-sm px-1.5 py-px text-[10px] font-bold uppercase tracking-[0.1em] font-mono leading-none bg-blue-500/8 text-blue-400/50 ring-1 ring-blue-500/10">
-                        YOU
-                      </span>
-                    </div>
-                    <p className="text-[13px] leading-relaxed text-neutral-500 italic">
-                      {interimTranscript}
-                      <span className="ml-1 inline-block h-3.5 w-[2px] bg-blue-400/50 animate-cursor-blink" />
-                    </p>
-                  </div>
+                    {msg.sender === "dispatcher" ? "DISP" : "YOU"}
+                  </span>
+                  <p className="text-sm leading-relaxed text-neutral-300">
+                    {msg.text}
+                  </p>
                 </div>
-              )}
-
+              ))}
               <div ref={transcriptEndRef} />
             </div>
-          </section>
+          </div>
         )}
 
-        {/* ── Footer ── */}
-        <footer>
-          <p className="text-center text-[11px] text-neutral-600 leading-relaxed">
-            This is a simulation. For real emergencies, call your local 911.
-          </p>
-        </footer>
+        {/* Footer */}
+        <p className="text-center text-xs text-neutral-600">
+          This is a simulation. For real emergencies, call your local 911.
+        </p>
       </div>
     </div>
   );

--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -1,0 +1,1482 @@
+"use client";
+
+import MapLibreGL, { type PopupOptions, type MarkerOptions } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { X, Minus, Plus, Locate, Maximize, Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// Check document class for theme (works with next-themes, etc.)
+function getDocumentTheme(): Theme | null {
+  if (typeof document === "undefined") return null;
+  if (document.documentElement.classList.contains("dark")) return "dark";
+  if (document.documentElement.classList.contains("light")) return "light";
+  return null;
+}
+
+// Get system preference
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function useResolvedTheme(themeProp?: "light" | "dark"): "light" | "dark" {
+  const [detectedTheme, setDetectedTheme] = useState<"light" | "dark">(
+    () => getDocumentTheme() ?? getSystemTheme()
+  );
+
+  useEffect(() => {
+    if (themeProp) return; // Skip detection if theme is provided via prop
+
+    // Watch for document class changes (e.g., next-themes toggling dark class)
+    const observer = new MutationObserver(() => {
+      const docTheme = getDocumentTheme();
+      if (docTheme) {
+        setDetectedTheme(docTheme);
+      }
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    // Also watch for system preference changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleSystemChange = (e: MediaQueryListEvent) => {
+      // Only use system preference if no document class is set
+      if (!getDocumentTheme()) {
+        setDetectedTheme(e.matches ? "dark" : "light");
+      }
+    };
+    mediaQuery.addEventListener("change", handleSystemChange);
+
+    return () => {
+      observer.disconnect();
+      mediaQuery.removeEventListener("change", handleSystemChange);
+    };
+  }, [themeProp]);
+
+  return themeProp ?? detectedTheme;
+}
+
+type MapContextValue = {
+  map: MapLibreGL.Map | null;
+  isLoaded: boolean;
+};
+
+const MapContext = createContext<MapContextValue | null>(null);
+
+function getViewport(map: MapLibreGL.Map): MapViewport {
+  const center = map.getCenter();
+  return {
+    center: [center.lng, center.lat],
+    zoom: map.getZoom(),
+    bearing: map.getBearing(),
+    pitch: map.getPitch(),
+  };
+}
+
+function useMap() {
+  const context = useContext(MapContext);
+  if (!context) {
+    throw new Error("useMap must be used within a Map component");
+  }
+  return context;
+}
+
+const defaultStyles = {
+  dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+  light: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+};
+
+type MapStyleOption = string | MapLibreGL.StyleSpecification;
+
+type Theme = "light" | "dark";
+
+/** Map viewport state */
+type MapViewport = {
+  /** Center coordinates [longitude, latitude] */
+  center: [number, number];
+  /** Zoom level */
+  zoom: number;
+  /** Bearing (rotation) in degrees */
+  bearing: number;
+  /** Pitch (tilt) in degrees */
+  pitch: number;
+};
+
+type MapProps = {
+  children?: ReactNode;
+  /** Additional CSS classes for the map container */
+  className?: string;
+  /**
+   * Theme for the map. If not provided, automatically detects system preference.
+   * Pass your theme value here.
+   */
+  theme?: Theme;
+  /** Custom map styles for light and dark themes. Overrides the default Carto styles. */
+  styles?: {
+    light?: MapStyleOption;
+    dark?: MapStyleOption;
+  };
+  /** Map projection type. Use `{ type: "globe" }` for 3D globe view. */
+  projection?: MapLibreGL.ProjectionSpecification;
+  /**
+   * Controlled viewport. When provided with onViewportChange,
+   * the map becomes controlled and viewport is driven by this prop.
+   */
+  viewport?: Partial<MapViewport>;
+  /**
+   * Callback fired continuously as the viewport changes (pan, zoom, rotate, pitch).
+   * Can be used standalone to observe changes, or with `viewport` prop
+   * to enable controlled mode where the map viewport is driven by your state.
+   */
+  onViewportChange?: (viewport: MapViewport) => void;
+} & Omit<MapLibreGL.MapOptions, "container" | "style">;
+
+type MapRef = MapLibreGL.Map;
+
+const DefaultLoader = () => (
+  <div className="absolute inset-0 flex items-center justify-center">
+    <div className="flex gap-1">
+      <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-pulse" />
+      <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-pulse [animation-delay:150ms]" />
+      <span className="size-1.5 rounded-full bg-muted-foreground/60 animate-pulse [animation-delay:300ms]" />
+    </div>
+  </div>
+);
+
+const Map = forwardRef<MapRef, MapProps>(function Map(
+  {
+    children,
+    className,
+    theme: themeProp,
+    styles,
+    projection,
+    viewport,
+    onViewportChange,
+    ...props
+  },
+  ref
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [mapInstance, setMapInstance] = useState<MapLibreGL.Map | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isStyleLoaded, setIsStyleLoaded] = useState(false);
+  const currentStyleRef = useRef<MapStyleOption | null>(null);
+  const styleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const internalUpdateRef = useRef(false);
+  const resolvedTheme = useResolvedTheme(themeProp);
+
+  const isControlled = viewport !== undefined && onViewportChange !== undefined;
+
+  const onViewportChangeRef = useRef(onViewportChange);
+  onViewportChangeRef.current = onViewportChange;
+
+  const mapStyles = useMemo(
+    () => ({
+      dark: styles?.dark ?? defaultStyles.dark,
+      light: styles?.light ?? defaultStyles.light,
+    }),
+    [styles]
+  );
+
+  // Expose the map instance to the parent component
+  useImperativeHandle(ref, () => mapInstance as MapLibreGL.Map, [mapInstance]);
+
+  const clearStyleTimeout = useCallback(() => {
+    if (styleTimeoutRef.current) {
+      clearTimeout(styleTimeoutRef.current);
+      styleTimeoutRef.current = null;
+    }
+  }, []);
+
+  // Initialize the map
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const initialStyle =
+      resolvedTheme === "dark" ? mapStyles.dark : mapStyles.light;
+    currentStyleRef.current = initialStyle;
+
+    const map = new MapLibreGL.Map({
+      container: containerRef.current,
+      style: initialStyle,
+      renderWorldCopies: false,
+      attributionControl: {
+        compact: true,
+      },
+      ...props,
+      ...viewport,
+    });
+
+    const styleDataHandler = () => {
+      clearStyleTimeout();
+      // Delay to ensure style is fully processed before allowing layer operations
+      // This is a workaround to avoid race conditions with the style loading
+      // else we have to force update every layer on setStyle change
+      styleTimeoutRef.current = setTimeout(() => {
+        setIsStyleLoaded(true);
+        if (projection) {
+          map.setProjection(projection);
+        }
+      }, 100);
+    };
+    const loadHandler = () => setIsLoaded(true);
+
+    // Viewport change handler - skip if triggered by internal update
+    const handleMove = () => {
+      if (internalUpdateRef.current) return;
+      onViewportChangeRef.current?.(getViewport(map));
+    };
+
+    map.on("load", loadHandler);
+    map.on("styledata", styleDataHandler);
+    map.on("move", handleMove);
+    setMapInstance(map);
+
+    return () => {
+      clearStyleTimeout();
+      map.off("load", loadHandler);
+      map.off("styledata", styleDataHandler);
+      map.off("move", handleMove);
+      map.remove();
+      setIsLoaded(false);
+      setIsStyleLoaded(false);
+      setMapInstance(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync controlled viewport to map
+  useEffect(() => {
+    if (!mapInstance || !isControlled || !viewport) return;
+    if (mapInstance.isMoving()) return;
+
+    const current = getViewport(mapInstance);
+    const next = {
+      center: viewport.center ?? current.center,
+      zoom: viewport.zoom ?? current.zoom,
+      bearing: viewport.bearing ?? current.bearing,
+      pitch: viewport.pitch ?? current.pitch,
+    };
+
+    if (
+      next.center[0] === current.center[0] &&
+      next.center[1] === current.center[1] &&
+      next.zoom === current.zoom &&
+      next.bearing === current.bearing &&
+      next.pitch === current.pitch
+    ) {
+      return;
+    }
+
+    internalUpdateRef.current = true;
+    mapInstance.jumpTo(next);
+    internalUpdateRef.current = false;
+  }, [mapInstance, isControlled, viewport]);
+
+  // Handle style change
+  useEffect(() => {
+    if (!mapInstance || !resolvedTheme) return;
+
+    const newStyle =
+      resolvedTheme === "dark" ? mapStyles.dark : mapStyles.light;
+
+    if (currentStyleRef.current === newStyle) return;
+
+    clearStyleTimeout();
+    currentStyleRef.current = newStyle;
+    setIsStyleLoaded(false);
+
+    mapInstance.setStyle(newStyle, { diff: true });
+  }, [mapInstance, resolvedTheme, mapStyles, clearStyleTimeout]);
+
+  const contextValue = useMemo(
+    () => ({
+      map: mapInstance,
+      isLoaded: isLoaded && isStyleLoaded,
+    }),
+    [mapInstance, isLoaded, isStyleLoaded]
+  );
+
+  return (
+    <MapContext.Provider value={contextValue}>
+      <div
+        ref={containerRef}
+        className={cn("relative w-full h-full", className)}
+      >
+        {!isLoaded && <DefaultLoader />}
+        {/* SSR-safe: children render only when map is loaded on client */}
+        {mapInstance && children}
+      </div>
+    </MapContext.Provider>
+  );
+});
+
+type MarkerContextValue = {
+  marker: MapLibreGL.Marker;
+  map: MapLibreGL.Map | null;
+};
+
+const MarkerContext = createContext<MarkerContextValue | null>(null);
+
+function useMarkerContext() {
+  const context = useContext(MarkerContext);
+  if (!context) {
+    throw new Error("Marker components must be used within MapMarker");
+  }
+  return context;
+}
+
+type MapMarkerProps = {
+  /** Longitude coordinate for marker position */
+  longitude: number;
+  /** Latitude coordinate for marker position */
+  latitude: number;
+  /** Marker subcomponents (MarkerContent, MarkerPopup, MarkerTooltip, MarkerLabel) */
+  children: ReactNode;
+  /** Callback when marker is clicked */
+  onClick?: (e: MouseEvent) => void;
+  /** Callback when mouse enters marker */
+  onMouseEnter?: (e: MouseEvent) => void;
+  /** Callback when mouse leaves marker */
+  onMouseLeave?: (e: MouseEvent) => void;
+  /** Callback when marker drag starts (requires draggable: true) */
+  onDragStart?: (lngLat: { lng: number; lat: number }) => void;
+  /** Callback during marker drag (requires draggable: true) */
+  onDrag?: (lngLat: { lng: number; lat: number }) => void;
+  /** Callback when marker drag ends (requires draggable: true) */
+  onDragEnd?: (lngLat: { lng: number; lat: number }) => void;
+} & Omit<MarkerOptions, "element">;
+
+function MapMarker({
+  longitude,
+  latitude,
+  children,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  onDragStart,
+  onDrag,
+  onDragEnd,
+  draggable = false,
+  ...markerOptions
+}: MapMarkerProps) {
+  const { map } = useMap();
+
+  const callbacksRef = useRef({
+    onClick,
+    onMouseEnter,
+    onMouseLeave,
+    onDragStart,
+    onDrag,
+    onDragEnd,
+  });
+  callbacksRef.current = {
+    onClick,
+    onMouseEnter,
+    onMouseLeave,
+    onDragStart,
+    onDrag,
+    onDragEnd,
+  };
+
+  const marker = useMemo(() => {
+    const markerInstance = new MapLibreGL.Marker({
+      ...markerOptions,
+      element: document.createElement("div"),
+      draggable,
+    }).setLngLat([longitude, latitude]);
+
+    const handleClick = (e: MouseEvent) => callbacksRef.current.onClick?.(e);
+    const handleMouseEnter = (e: MouseEvent) =>
+      callbacksRef.current.onMouseEnter?.(e);
+    const handleMouseLeave = (e: MouseEvent) =>
+      callbacksRef.current.onMouseLeave?.(e);
+
+    markerInstance.getElement()?.addEventListener("click", handleClick);
+    markerInstance
+      .getElement()
+      ?.addEventListener("mouseenter", handleMouseEnter);
+    markerInstance
+      .getElement()
+      ?.addEventListener("mouseleave", handleMouseLeave);
+
+    const handleDragStart = () => {
+      const lngLat = markerInstance.getLngLat();
+      callbacksRef.current.onDragStart?.({ lng: lngLat.lng, lat: lngLat.lat });
+    };
+    const handleDrag = () => {
+      const lngLat = markerInstance.getLngLat();
+      callbacksRef.current.onDrag?.({ lng: lngLat.lng, lat: lngLat.lat });
+    };
+    const handleDragEnd = () => {
+      const lngLat = markerInstance.getLngLat();
+      callbacksRef.current.onDragEnd?.({ lng: lngLat.lng, lat: lngLat.lat });
+    };
+
+    markerInstance.on("dragstart", handleDragStart);
+    markerInstance.on("drag", handleDrag);
+    markerInstance.on("dragend", handleDragEnd);
+
+    return markerInstance;
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!map) return;
+
+    marker.addTo(map);
+
+    return () => {
+      marker.remove();
+    };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  if (
+    marker.getLngLat().lng !== longitude ||
+    marker.getLngLat().lat !== latitude
+  ) {
+    marker.setLngLat([longitude, latitude]);
+  }
+  if (marker.isDraggable() !== draggable) {
+    marker.setDraggable(draggable);
+  }
+
+  const currentOffset = marker.getOffset();
+  const newOffset = markerOptions.offset ?? [0, 0];
+  const [newOffsetX, newOffsetY] = Array.isArray(newOffset)
+    ? newOffset
+    : [newOffset.x, newOffset.y];
+  if (currentOffset.x !== newOffsetX || currentOffset.y !== newOffsetY) {
+    marker.setOffset(newOffset);
+  }
+
+  if (marker.getRotation() !== markerOptions.rotation) {
+    marker.setRotation(markerOptions.rotation ?? 0);
+  }
+  if (marker.getRotationAlignment() !== markerOptions.rotationAlignment) {
+    marker.setRotationAlignment(markerOptions.rotationAlignment ?? "auto");
+  }
+  if (marker.getPitchAlignment() !== markerOptions.pitchAlignment) {
+    marker.setPitchAlignment(markerOptions.pitchAlignment ?? "auto");
+  }
+
+  return (
+    <MarkerContext.Provider value={{ marker, map }}>
+      {children}
+    </MarkerContext.Provider>
+  );
+}
+
+type MarkerContentProps = {
+  /** Custom marker content. Defaults to a blue dot if not provided */
+  children?: ReactNode;
+  /** Additional CSS classes for the marker container */
+  className?: string;
+};
+
+function MarkerContent({ children, className }: MarkerContentProps) {
+  const { marker } = useMarkerContext();
+
+  return createPortal(
+    <div className={cn("relative cursor-pointer", className)}>
+      {children || <DefaultMarkerIcon />}
+    </div>,
+    marker.getElement()
+  );
+}
+
+function DefaultMarkerIcon() {
+  return (
+    <div className="relative h-4 w-4 rounded-full border-2 border-white bg-blue-500 shadow-lg" />
+  );
+}
+
+type MarkerPopupProps = {
+  /** Popup content */
+  children: ReactNode;
+  /** Additional CSS classes for the popup container */
+  className?: string;
+  /** Show a close button in the popup (default: false) */
+  closeButton?: boolean;
+} & Omit<PopupOptions, "className" | "closeButton">;
+
+function MarkerPopup({
+  children,
+  className,
+  closeButton = false,
+  ...popupOptions
+}: MarkerPopupProps) {
+  const { marker, map } = useMarkerContext();
+  const container = useMemo(() => document.createElement("div"), []);
+  const prevPopupOptions = useRef(popupOptions);
+
+  const popup = useMemo(() => {
+    const popupInstance = new MapLibreGL.Popup({
+      offset: 16,
+      ...popupOptions,
+      closeButton: false,
+    })
+      .setMaxWidth("none")
+      .setDOMContent(container);
+
+    return popupInstance;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!map) return;
+
+    popup.setDOMContent(container);
+    marker.setPopup(popup);
+
+    return () => {
+      marker.setPopup(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  if (popup.isOpen()) {
+    const prev = prevPopupOptions.current;
+
+    if (prev.offset !== popupOptions.offset) {
+      popup.setOffset(popupOptions.offset ?? 16);
+    }
+    if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
+      popup.setMaxWidth(popupOptions.maxWidth ?? "none");
+    }
+
+    prevPopupOptions.current = popupOptions;
+  }
+
+  const handleClose = () => popup.remove();
+
+  return createPortal(
+    <div
+      className={cn(
+        "relative rounded-md border bg-popover p-3 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95",
+        className
+      )}
+    >
+      {closeButton && (
+        <button
+          type="button"
+          onClick={handleClose}
+          className="absolute top-1 right-1 z-10 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          aria-label="Close popup"
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </button>
+      )}
+      {children}
+    </div>,
+    container
+  );
+}
+
+type MarkerTooltipProps = {
+  /** Tooltip content */
+  children: ReactNode;
+  /** Additional CSS classes for the tooltip container */
+  className?: string;
+} & Omit<PopupOptions, "className" | "closeButton" | "closeOnClick">;
+
+function MarkerTooltip({
+  children,
+  className,
+  ...popupOptions
+}: MarkerTooltipProps) {
+  const { marker, map } = useMarkerContext();
+  const container = useMemo(() => document.createElement("div"), []);
+  const prevTooltipOptions = useRef(popupOptions);
+
+  const tooltip = useMemo(() => {
+    const tooltipInstance = new MapLibreGL.Popup({
+      offset: 16,
+      ...popupOptions,
+      closeOnClick: true,
+      closeButton: false,
+    }).setMaxWidth("none");
+
+    return tooltipInstance;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!map) return;
+
+    tooltip.setDOMContent(container);
+
+    const handleMouseEnter = () => {
+      tooltip.setLngLat(marker.getLngLat()).addTo(map);
+    };
+    const handleMouseLeave = () => tooltip.remove();
+
+    marker.getElement()?.addEventListener("mouseenter", handleMouseEnter);
+    marker.getElement()?.addEventListener("mouseleave", handleMouseLeave);
+
+    return () => {
+      marker.getElement()?.removeEventListener("mouseenter", handleMouseEnter);
+      marker.getElement()?.removeEventListener("mouseleave", handleMouseLeave);
+      tooltip.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  if (tooltip.isOpen()) {
+    const prev = prevTooltipOptions.current;
+
+    if (prev.offset !== popupOptions.offset) {
+      tooltip.setOffset(popupOptions.offset ?? 16);
+    }
+    if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
+      tooltip.setMaxWidth(popupOptions.maxWidth ?? "none");
+    }
+
+    prevTooltipOptions.current = popupOptions;
+  }
+
+  return createPortal(
+    <div
+      className={cn(
+        "rounded-md bg-foreground px-2 py-1 text-xs text-background shadow-md animate-in fade-in-0 zoom-in-95",
+        className
+      )}
+    >
+      {children}
+    </div>,
+    container
+  );
+}
+
+type MarkerLabelProps = {
+  /** Label text content */
+  children: ReactNode;
+  /** Additional CSS classes for the label */
+  className?: string;
+  /** Position of the label relative to the marker (default: "top") */
+  position?: "top" | "bottom";
+};
+
+function MarkerLabel({
+  children,
+  className,
+  position = "top",
+}: MarkerLabelProps) {
+  const positionClasses = {
+    top: "bottom-full mb-1",
+    bottom: "top-full mt-1",
+  };
+
+  return (
+    <div
+      className={cn(
+        "absolute left-1/2 -translate-x-1/2 whitespace-nowrap",
+        "text-[10px] font-medium text-foreground",
+        positionClasses[position],
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type MapControlsProps = {
+  /** Position of the controls on the map (default: "bottom-right") */
+  position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+  /** Show zoom in/out buttons (default: true) */
+  showZoom?: boolean;
+  /** Show compass button to reset bearing (default: false) */
+  showCompass?: boolean;
+  /** Show locate button to find user's location (default: false) */
+  showLocate?: boolean;
+  /** Show fullscreen toggle button (default: false) */
+  showFullscreen?: boolean;
+  /** Additional CSS classes for the controls container */
+  className?: string;
+  /** Callback with user coordinates when located */
+  onLocate?: (coords: { longitude: number; latitude: number }) => void;
+};
+
+const positionClasses = {
+  "top-left": "top-2 left-2",
+  "top-right": "top-2 right-2",
+  "bottom-left": "bottom-2 left-2",
+  "bottom-right": "bottom-10 right-2",
+};
+
+function ControlGroup({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col rounded-md border border-border bg-background shadow-sm overflow-hidden [&>button:not(:last-child)]:border-b [&>button:not(:last-child)]:border-border">
+      {children}
+    </div>
+  );
+}
+
+function ControlButton({
+  onClick,
+  label,
+  children,
+  disabled = false,
+}: {
+  onClick: () => void;
+  label: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      type="button"
+      className={cn(
+        "flex items-center justify-center size-8 hover:bg-accent dark:hover:bg-accent/40 transition-colors",
+        disabled && "opacity-50 pointer-events-none cursor-not-allowed"
+      )}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MapControls({
+  position = "bottom-right",
+  showZoom = true,
+  showCompass = false,
+  showLocate = false,
+  showFullscreen = false,
+  className,
+  onLocate,
+}: MapControlsProps) {
+  const { map } = useMap();
+  const [waitingForLocation, setWaitingForLocation] = useState(false);
+
+  const handleZoomIn = useCallback(() => {
+    map?.zoomTo(map.getZoom() + 1, { duration: 300 });
+  }, [map]);
+
+  const handleZoomOut = useCallback(() => {
+    map?.zoomTo(map.getZoom() - 1, { duration: 300 });
+  }, [map]);
+
+  const handleResetBearing = useCallback(() => {
+    map?.resetNorthPitch({ duration: 300 });
+  }, [map]);
+
+  const handleLocate = useCallback(() => {
+    setWaitingForLocation(true);
+    if ("geolocation" in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const coords = {
+            longitude: pos.coords.longitude,
+            latitude: pos.coords.latitude,
+          };
+          map?.flyTo({
+            center: [coords.longitude, coords.latitude],
+            zoom: 14,
+            duration: 1500,
+          });
+          onLocate?.(coords);
+          setWaitingForLocation(false);
+        },
+        (error) => {
+          console.error("Error getting location:", error);
+          setWaitingForLocation(false);
+        }
+      );
+    }
+  }, [map, onLocate]);
+
+  const handleFullscreen = useCallback(() => {
+    const container = map?.getContainer();
+    if (!container) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      container.requestFullscreen();
+    }
+  }, [map]);
+
+  return (
+    <div
+      className={cn(
+        "absolute z-10 flex flex-col gap-1.5",
+        positionClasses[position],
+        className
+      )}
+    >
+      {showZoom && (
+        <ControlGroup>
+          <ControlButton onClick={handleZoomIn} label="Zoom in">
+            <Plus className="size-4" />
+          </ControlButton>
+          <ControlButton onClick={handleZoomOut} label="Zoom out">
+            <Minus className="size-4" />
+          </ControlButton>
+        </ControlGroup>
+      )}
+      {showCompass && (
+        <ControlGroup>
+          <CompassButton onClick={handleResetBearing} />
+        </ControlGroup>
+      )}
+      {showLocate && (
+        <ControlGroup>
+          <ControlButton
+            onClick={handleLocate}
+            label="Find my location"
+            disabled={waitingForLocation}
+          >
+            {waitingForLocation ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Locate className="size-4" />
+            )}
+          </ControlButton>
+        </ControlGroup>
+      )}
+      {showFullscreen && (
+        <ControlGroup>
+          <ControlButton onClick={handleFullscreen} label="Toggle fullscreen">
+            <Maximize className="size-4" />
+          </ControlButton>
+        </ControlGroup>
+      )}
+    </div>
+  );
+}
+
+function CompassButton({ onClick }: { onClick: () => void }) {
+  const { map } = useMap();
+  const compassRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!map || !compassRef.current) return;
+
+    const compass = compassRef.current;
+
+    const updateRotation = () => {
+      const bearing = map.getBearing();
+      const pitch = map.getPitch();
+      compass.style.transform = `rotateX(${pitch}deg) rotateZ(${-bearing}deg)`;
+    };
+
+    map.on("rotate", updateRotation);
+    map.on("pitch", updateRotation);
+    updateRotation();
+
+    return () => {
+      map.off("rotate", updateRotation);
+      map.off("pitch", updateRotation);
+    };
+  }, [map]);
+
+  return (
+    <ControlButton onClick={onClick} label="Reset bearing to north">
+      <svg
+        ref={compassRef}
+        viewBox="0 0 24 24"
+        className="size-5 transition-transform duration-200"
+        style={{ transformStyle: "preserve-3d" }}
+      >
+        <path d="M12 2L16 12H12V2Z" className="fill-red-500" />
+        <path d="M12 2L8 12H12V2Z" className="fill-red-300" />
+        <path d="M12 22L16 12H12V22Z" className="fill-muted-foreground/60" />
+        <path d="M12 22L8 12H12V22Z" className="fill-muted-foreground/30" />
+      </svg>
+    </ControlButton>
+  );
+}
+
+type MapPopupProps = {
+  /** Longitude coordinate for popup position */
+  longitude: number;
+  /** Latitude coordinate for popup position */
+  latitude: number;
+  /** Callback when popup is closed */
+  onClose?: () => void;
+  /** Popup content */
+  children: ReactNode;
+  /** Additional CSS classes for the popup container */
+  className?: string;
+  /** Show a close button in the popup (default: false) */
+  closeButton?: boolean;
+} & Omit<PopupOptions, "className" | "closeButton">;
+
+function MapPopup({
+  longitude,
+  latitude,
+  onClose,
+  children,
+  className,
+  closeButton = false,
+  ...popupOptions
+}: MapPopupProps) {
+  const { map } = useMap();
+  const popupOptionsRef = useRef(popupOptions);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const container = useMemo(() => document.createElement("div"), []);
+
+  const popup = useMemo(() => {
+    const popupInstance = new MapLibreGL.Popup({
+      offset: 16,
+      ...popupOptions,
+      closeButton: false,
+    })
+      .setMaxWidth("none")
+      .setLngLat([longitude, latitude]);
+
+    return popupInstance;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const onCloseProp = () => onCloseRef.current?.();
+
+    popup.on("close", onCloseProp);
+
+    popup.setDOMContent(container);
+    popup.addTo(map);
+
+    return () => {
+      popup.off("close", onCloseProp);
+      if (popup.isOpen()) {
+        popup.remove();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  if (popup.isOpen()) {
+    const prev = popupOptionsRef.current;
+
+    if (
+      popup.getLngLat().lng !== longitude ||
+      popup.getLngLat().lat !== latitude
+    ) {
+      popup.setLngLat([longitude, latitude]);
+    }
+
+    if (prev.offset !== popupOptions.offset) {
+      popup.setOffset(popupOptions.offset ?? 16);
+    }
+    if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
+      popup.setMaxWidth(popupOptions.maxWidth ?? "none");
+    }
+    popupOptionsRef.current = popupOptions;
+  }
+
+  const handleClose = () => {
+    popup.remove();
+  };
+
+  return createPortal(
+    <div
+      className={cn(
+        "relative rounded-md border bg-popover p-3 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95",
+        className
+      )}
+    >
+      {closeButton && (
+        <button
+          type="button"
+          onClick={handleClose}
+          className="absolute top-1 right-1 z-10 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          aria-label="Close popup"
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </button>
+      )}
+      {children}
+    </div>,
+    container
+  );
+}
+
+type MapRouteProps = {
+  /** Optional unique identifier for the route layer */
+  id?: string;
+  /** Array of [longitude, latitude] coordinate pairs defining the route */
+  coordinates: [number, number][];
+  /** Line color as CSS color value (default: "#4285F4") */
+  color?: string;
+  /** Line width in pixels (default: 3) */
+  width?: number;
+  /** Line opacity from 0 to 1 (default: 0.8) */
+  opacity?: number;
+  /** Dash pattern [dash length, gap length] for dashed lines */
+  dashArray?: [number, number];
+  /** Callback when the route line is clicked */
+  onClick?: () => void;
+  /** Callback when mouse enters the route line */
+  onMouseEnter?: () => void;
+  /** Callback when mouse leaves the route line */
+  onMouseLeave?: () => void;
+  /** Whether the route is interactive - shows pointer cursor on hover (default: true) */
+  interactive?: boolean;
+};
+
+function MapRoute({
+  id: propId,
+  coordinates,
+  color = "#4285F4",
+  width = 3,
+  opacity = 0.8,
+  dashArray,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  interactive = true,
+}: MapRouteProps) {
+  const { map, isLoaded } = useMap();
+  const autoId = useId();
+  const id = propId ?? autoId;
+  const sourceId = `route-source-${id}`;
+  const layerId = `route-layer-${id}`;
+
+  // Add source and layer on mount
+  useEffect(() => {
+    if (!isLoaded || !map) return;
+
+    map.addSource(sourceId, {
+      type: "geojson",
+      data: {
+        type: "Feature",
+        properties: {},
+        geometry: { type: "LineString", coordinates: [] },
+      },
+    });
+
+    map.addLayer({
+      id: layerId,
+      type: "line",
+      source: sourceId,
+      layout: { "line-join": "round", "line-cap": "round" },
+      paint: {
+        "line-color": color,
+        "line-width": width,
+        "line-opacity": opacity,
+        ...(dashArray && { "line-dasharray": dashArray }),
+      },
+    });
+
+    return () => {
+      try {
+        if (map.getLayer(layerId)) map.removeLayer(layerId);
+        if (map.getSource(sourceId)) map.removeSource(sourceId);
+      } catch {
+        // ignore
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded, map]);
+
+  // When coordinates change, update the source data
+  useEffect(() => {
+    if (!isLoaded || !map || coordinates.length < 2) return;
+
+    const source = map.getSource(sourceId) as MapLibreGL.GeoJSONSource;
+    if (source) {
+      source.setData({
+        type: "Feature",
+        properties: {},
+        geometry: { type: "LineString", coordinates },
+      });
+    }
+  }, [isLoaded, map, coordinates, sourceId]);
+
+  useEffect(() => {
+    if (!isLoaded || !map || !map.getLayer(layerId)) return;
+
+    map.setPaintProperty(layerId, "line-color", color);
+    map.setPaintProperty(layerId, "line-width", width);
+    map.setPaintProperty(layerId, "line-opacity", opacity);
+    if (dashArray) {
+      map.setPaintProperty(layerId, "line-dasharray", dashArray);
+    }
+  }, [isLoaded, map, layerId, color, width, opacity, dashArray]);
+
+  // Handle click and hover events
+  useEffect(() => {
+    if (!isLoaded || !map || !interactive) return;
+
+    const handleClick = () => {
+      onClick?.();
+    };
+    const handleMouseEnter = () => {
+      map.getCanvas().style.cursor = "pointer";
+      onMouseEnter?.();
+    };
+    const handleMouseLeave = () => {
+      map.getCanvas().style.cursor = "";
+      onMouseLeave?.();
+    };
+
+    map.on("click", layerId, handleClick);
+    map.on("mouseenter", layerId, handleMouseEnter);
+    map.on("mouseleave", layerId, handleMouseLeave);
+
+    return () => {
+      map.off("click", layerId, handleClick);
+      map.off("mouseenter", layerId, handleMouseEnter);
+      map.off("mouseleave", layerId, handleMouseLeave);
+    };
+  }, [
+    isLoaded,
+    map,
+    layerId,
+    onClick,
+    onMouseEnter,
+    onMouseLeave,
+    interactive,
+  ]);
+
+  return null;
+}
+
+type MapClusterLayerProps<
+  P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonProperties
+> = {
+  /** GeoJSON FeatureCollection data or URL to fetch GeoJSON from */
+  data: string | GeoJSON.FeatureCollection<GeoJSON.Point, P>;
+  /** Maximum zoom level to cluster points on (default: 14) */
+  clusterMaxZoom?: number;
+  /** Radius of each cluster when clustering points in pixels (default: 50) */
+  clusterRadius?: number;
+  /** Colors for cluster circles: [small, medium, large] based on point count (default: ["#22c55e", "#eab308", "#ef4444"]) */
+  clusterColors?: [string, string, string];
+  /** Point count thresholds for color/size steps: [medium, large] (default: [100, 750]) */
+  clusterThresholds?: [number, number];
+  /** Color for unclustered individual points (default: "#3b82f6") */
+  pointColor?: string;
+  /** Callback when an unclustered point is clicked */
+  onPointClick?: (
+    feature: GeoJSON.Feature<GeoJSON.Point, P>,
+    coordinates: [number, number]
+  ) => void;
+  /** Callback when a cluster is clicked. If not provided, zooms into the cluster */
+  onClusterClick?: (
+    clusterId: number,
+    coordinates: [number, number],
+    pointCount: number
+  ) => void;
+};
+
+function MapClusterLayer<
+  P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonProperties
+>({
+  data,
+  clusterMaxZoom = 14,
+  clusterRadius = 50,
+  clusterColors = ["#22c55e", "#eab308", "#ef4444"],
+  clusterThresholds = [100, 750],
+  pointColor = "#3b82f6",
+  onPointClick,
+  onClusterClick,
+}: MapClusterLayerProps<P>) {
+  const { map, isLoaded } = useMap();
+  const id = useId();
+  const sourceId = `cluster-source-${id}`;
+  const clusterLayerId = `clusters-${id}`;
+  const clusterCountLayerId = `cluster-count-${id}`;
+  const unclusteredLayerId = `unclustered-point-${id}`;
+
+  const stylePropsRef = useRef({
+    clusterColors,
+    clusterThresholds,
+    pointColor,
+  });
+
+  // Add source and layers on mount
+  useEffect(() => {
+    if (!isLoaded || !map) return;
+
+    // Add clustered GeoJSON source
+    map.addSource(sourceId, {
+      type: "geojson",
+      data,
+      cluster: true,
+      clusterMaxZoom,
+      clusterRadius,
+    });
+
+    // Add cluster circles layer
+    map.addLayer({
+      id: clusterLayerId,
+      type: "circle",
+      source: sourceId,
+      filter: ["has", "point_count"],
+      paint: {
+        "circle-color": [
+          "step",
+          ["get", "point_count"],
+          clusterColors[0],
+          clusterThresholds[0],
+          clusterColors[1],
+          clusterThresholds[1],
+          clusterColors[2],
+        ],
+        "circle-radius": [
+          "step",
+          ["get", "point_count"],
+          20,
+          clusterThresholds[0],
+          30,
+          clusterThresholds[1],
+          40,
+        ],
+        "circle-stroke-width": 1,
+        "circle-stroke-color": "#fff",
+        "circle-opacity": 0.85,
+      },
+    });
+
+    // Add cluster count text layer
+    map.addLayer({
+      id: clusterCountLayerId,
+      type: "symbol",
+      source: sourceId,
+      filter: ["has", "point_count"],
+      layout: {
+        "text-field": "{point_count_abbreviated}",
+        "text-size": 12,
+      },
+      paint: {
+        "text-color": "#fff",
+      },
+    });
+
+    // Add unclustered point layer
+    map.addLayer({
+      id: unclusteredLayerId,
+      type: "circle",
+      source: sourceId,
+      filter: ["!", ["has", "point_count"]],
+      paint: {
+        "circle-color": pointColor,
+        "circle-radius": 5,
+        "circle-stroke-width": 2,
+        "circle-stroke-color": "#fff",
+      },
+    });
+
+    return () => {
+      try {
+        if (map.getLayer(clusterCountLayerId))
+          map.removeLayer(clusterCountLayerId);
+        if (map.getLayer(unclusteredLayerId))
+          map.removeLayer(unclusteredLayerId);
+        if (map.getLayer(clusterLayerId)) map.removeLayer(clusterLayerId);
+        if (map.getSource(sourceId)) map.removeSource(sourceId);
+      } catch {
+        // ignore
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded, map, sourceId]);
+
+  // Update source data when data prop changes (only for non-URL data)
+  useEffect(() => {
+    if (!isLoaded || !map || typeof data === "string") return;
+
+    const source = map.getSource(sourceId) as MapLibreGL.GeoJSONSource;
+    if (source) {
+      source.setData(data);
+    }
+  }, [isLoaded, map, data, sourceId]);
+
+  // Update layer styles when props change
+  useEffect(() => {
+    if (!isLoaded || !map) return;
+
+    const prev = stylePropsRef.current;
+    const colorsChanged =
+      prev.clusterColors !== clusterColors ||
+      prev.clusterThresholds !== clusterThresholds;
+
+    // Update cluster layer colors and sizes
+    if (map.getLayer(clusterLayerId) && colorsChanged) {
+      map.setPaintProperty(clusterLayerId, "circle-color", [
+        "step",
+        ["get", "point_count"],
+        clusterColors[0],
+        clusterThresholds[0],
+        clusterColors[1],
+        clusterThresholds[1],
+        clusterColors[2],
+      ]);
+      map.setPaintProperty(clusterLayerId, "circle-radius", [
+        "step",
+        ["get", "point_count"],
+        20,
+        clusterThresholds[0],
+        30,
+        clusterThresholds[1],
+        40,
+      ]);
+    }
+
+    // Update unclustered point layer color
+    if (map.getLayer(unclusteredLayerId) && prev.pointColor !== pointColor) {
+      map.setPaintProperty(unclusteredLayerId, "circle-color", pointColor);
+    }
+
+    stylePropsRef.current = { clusterColors, clusterThresholds, pointColor };
+  }, [
+    isLoaded,
+    map,
+    clusterLayerId,
+    unclusteredLayerId,
+    clusterColors,
+    clusterThresholds,
+    pointColor,
+  ]);
+
+  // Handle click events
+  useEffect(() => {
+    if (!isLoaded || !map) return;
+
+    // Cluster click handler - zoom into cluster
+    const handleClusterClick = async (
+      e: MapLibreGL.MapMouseEvent & {
+        features?: MapLibreGL.MapGeoJSONFeature[];
+      }
+    ) => {
+      const features = map.queryRenderedFeatures(e.point, {
+        layers: [clusterLayerId],
+      });
+      if (!features.length) return;
+
+      const feature = features[0];
+      const clusterId = feature.properties?.cluster_id as number;
+      const pointCount = feature.properties?.point_count as number;
+      const coordinates = (feature.geometry as GeoJSON.Point).coordinates as [
+        number,
+        number
+      ];
+
+      if (onClusterClick) {
+        onClusterClick(clusterId, coordinates, pointCount);
+      } else {
+        // Default behavior: zoom to cluster expansion zoom
+        const source = map.getSource(sourceId) as MapLibreGL.GeoJSONSource;
+        const zoom = await source.getClusterExpansionZoom(clusterId);
+        map.easeTo({
+          center: coordinates,
+          zoom,
+        });
+      }
+    };
+
+    // Unclustered point click handler
+    const handlePointClick = (
+      e: MapLibreGL.MapMouseEvent & {
+        features?: MapLibreGL.MapGeoJSONFeature[];
+      }
+    ) => {
+      if (!onPointClick || !e.features?.length) return;
+
+      const feature = e.features[0];
+      const coordinates = (
+        feature.geometry as GeoJSON.Point
+      ).coordinates.slice() as [number, number];
+
+      // Handle world copies
+      while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+        coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+      }
+
+      onPointClick(
+        feature as unknown as GeoJSON.Feature<GeoJSON.Point, P>,
+        coordinates
+      );
+    };
+
+    // Cursor style handlers
+    const handleMouseEnterCluster = () => {
+      map.getCanvas().style.cursor = "pointer";
+    };
+    const handleMouseLeaveCluster = () => {
+      map.getCanvas().style.cursor = "";
+    };
+    const handleMouseEnterPoint = () => {
+      if (onPointClick) {
+        map.getCanvas().style.cursor = "pointer";
+      }
+    };
+    const handleMouseLeavePoint = () => {
+      map.getCanvas().style.cursor = "";
+    };
+
+    map.on("click", clusterLayerId, handleClusterClick);
+    map.on("click", unclusteredLayerId, handlePointClick);
+    map.on("mouseenter", clusterLayerId, handleMouseEnterCluster);
+    map.on("mouseleave", clusterLayerId, handleMouseLeaveCluster);
+    map.on("mouseenter", unclusteredLayerId, handleMouseEnterPoint);
+    map.on("mouseleave", unclusteredLayerId, handleMouseLeavePoint);
+
+    return () => {
+      map.off("click", clusterLayerId, handleClusterClick);
+      map.off("click", unclusteredLayerId, handlePointClick);
+      map.off("mouseenter", clusterLayerId, handleMouseEnterCluster);
+      map.off("mouseleave", clusterLayerId, handleMouseLeaveCluster);
+      map.off("mouseenter", unclusteredLayerId, handleMouseEnterPoint);
+      map.off("mouseleave", unclusteredLayerId, handleMouseLeavePoint);
+    };
+  }, [
+    isLoaded,
+    map,
+    clusterLayerId,
+    unclusteredLayerId,
+    sourceId,
+    onClusterClick,
+    onPointClick,
+  ]);
+
+  return null;
+}
+
+export {
+  Map,
+  useMap,
+  MapMarker,
+  MarkerContent,
+  MarkerPopup,
+  MarkerTooltip,
+  MarkerLabel,
+  MapPopup,
+  MapControls,
+  MapRoute,
+  MapClusterLayer,
+};
+
+export type { MapRef, MapViewport };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.564.0",
+    "maplibre-gl": "^5.18.0",
     "next": "16.1.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.3)
+      maplibre-gl:
+        specifier: ^5.18.0
+        version: 5.18.0
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -999,6 +1002,43 @@ packages:
   '@lukeed/uuid@2.0.1':
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
+
+  '@mapbox/geojson-rewind@0.5.2':
+    resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
+    hasBin: true
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.0.7':
+    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.6':
+    resolution: {integrity: sha512-rgtY3x65lrrfXycLf6/T22ZnjTg5WgIOsptOIoCaMZy4O4UAKTyZlYY0h6v8le721pTptF94U65yMDQkug+URw==}
+
+  '@maplibre/vt-pbf@4.2.1':
+    resolution: {integrity: sha512-IxZBGq/+9cqf2qdWlFuQ+ZfoMhWpxDUGQZ/poPHOJBvwMUT1GuxLo6HgYTou+xxtsOsjfbcjI8PZaPCtmt97rA==}
 
   '@mastra/core@1.4.0':
     resolution: {integrity: sha512-dyCUFozUGXwyNLl5zRZbKFKemp4gfk+vTsrfgv9M08OlXl2AuLgc+J6Yyj9gFwBVCTgxPaKUtu3QaDOiproXrg==}
@@ -2256,6 +2296,9 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -2299,6 +2342,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -2981,6 +3027,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -3442,6 +3491,9 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3862,6 +3914,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -3877,6 +3932,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3906,6 +3964,7 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.30.2:
@@ -4024,6 +4083,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  maplibre-gl@5.18.0:
+    resolution: {integrity: sha512-UtWxPBpHuFvEkM+5FVfcFG9ZKEWZQI6+PZkvLErr8Zs5ux+O7/KQ3JjSUvAfOlMeMgd/77qlHpOw0yHL7JU5cw==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   mastra@1.3.1:
     resolution: {integrity: sha512-E5I3oUNEMxbMzjTLd3iLcjFs7oCu43NqYR1vsI0M72KVPbx/wu5/l8ZUFwYaHpjWn+kKjRcDwTLGG8DkMAfucw==}
     engines: {node: '>=22.13.0'}
@@ -4135,6 +4198,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -4358,6 +4424,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4413,6 +4483,9 @@ packages:
     resolution: {integrity: sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ==}
     engines: {node: '>=20'}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -4443,6 +4516,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -4469,6 +4545,9 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   radash@12.1.1:
     resolution: {integrity: sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==}
@@ -4594,6 +4673,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -4640,6 +4722,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -4907,6 +4992,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4946,6 +5034,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
@@ -6067,6 +6158,53 @@ snapshots:
   '@lukeed/uuid@2.0.1':
     dependencies:
       '@lukeed/csprng': 1.1.0
+
+  '@mapbox/geojson-rewind@0.5.2':
+    dependencies:
+      get-stream: 6.0.1
+      minimist: 1.2.8
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.0.7': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.6':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.2.1':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.1
+      supercluster: 8.0.1
 
   '@mastra/core@1.4.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)':
     dependencies:
@@ -7339,6 +7477,8 @@ snapshots:
       '@types/qs': 6.14.0
       '@types/serve-static': 1.15.10
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
@@ -7381,6 +7521,10 @@ snapshots:
       '@types/send': 0.17.6
 
   '@types/statuses@2.0.6': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -8049,6 +8193,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -8776,6 +8922,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -9127,6 +9275,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -9145,6 +9295,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:
@@ -9284,6 +9436,31 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@5.18.0:
+    dependencies:
+      '@mapbox/geojson-rewind': 0.5.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 5.0.4
+      '@maplibre/maplibre-gl-style-spec': 24.4.1
+      '@maplibre/mlt': 1.1.6
+      '@maplibre/vt-pbf': 4.2.1
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
   mastra@1.3.1(@mastra/core@1.4.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@clack/prompts': 0.11.0
@@ -9405,6 +9582,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+
+  murmurhash-js@1.0.0: {}
 
   mute-stream@2.0.0: {}
 
@@ -9620,6 +9799,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -9699,6 +9882,8 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
+  potpack@2.1.0: {}
+
   powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
@@ -9724,6 +9909,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protocol-buffers-schema@3.6.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -9747,6 +9934,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  quickselect@3.0.0: {}
 
   radash@12.1.1: {}
 
@@ -9925,6 +10114,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.11:
@@ -10005,6 +10198,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -10410,6 +10605,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10438,6 +10637,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyqueue@3.0.0: {}
 
   tldts-core@7.0.23: {}
 


### PR DESCRIPTION
  - Added new dashboard route structure and pages:
    - `/dashboard` (overview)
    - `/dashboard/queue`
    - `/dashboard/simulator`
  - Updated dashboard shell/navigation styling and layout consistency.
  - Moved simulator experience under dashboard context and updated nav links.
  - Changed root route (`/`) to redirect to `/dashboard`.
  - Added reusable map UI component and MapLibre dependency.
  - Improved map marker visibility with clearer, high-contrast dot styling.
  - Applied simulator/dashboard visual cleanup and neutralized overly saturated styles.